### PR TITLE
add conversions from base types to string

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -285,11 +285,6 @@ func (d Decoder) decodeString(to reflect.Value) (t Type, err error) {
 	return
 }
 
-var (
-	trueBytes  = [...]byte{'t', 'r', 'u', 'e'}
-	falseBytes = [...]byte{'f', 'a', 'l', 's', 'e'}
-)
-
 func (d Decoder) decodeStringFromType(t Type, to reflect.Value) (err error) {
 	var a [64]byte
 	var b []byte
@@ -308,9 +303,9 @@ func (d Decoder) decodeStringFromType(t Type, to reflect.Value) (err error) {
 		var v bool
 		if v, err = d.Parser.ParseBool(); err == nil {
 			if v {
-				b = trueBytes[:]
+				b = append(a[:0], "true"...)
 			} else {
-				b = falseBytes[:]
+				b = append(a[:0], "false"...)
 			}
 		}
 

--- a/decode.go
+++ b/decode.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"time"
 )
 
@@ -284,7 +285,13 @@ func (d Decoder) decodeString(to reflect.Value) (t Type, err error) {
 	return
 }
 
+var (
+	trueBytes  = [...]byte{'t', 'r', 'u', 'e'}
+	falseBytes = [...]byte{'f', 'a', 'l', 's', 'e'}
+)
+
 func (d Decoder) decodeStringFromType(t Type, to reflect.Value) (err error) {
+	var a [64]byte
 	var b []byte
 
 	switch t {
@@ -296,6 +303,52 @@ func (d Decoder) decodeStringFromType(t Type, to reflect.Value) (err error) {
 
 	case Bytes:
 		b, err = d.Parser.ParseBytes()
+
+	case Bool:
+		var v bool
+		if v, err = d.Parser.ParseBool(); err == nil {
+			if v {
+				b = trueBytes[:]
+			} else {
+				b = falseBytes[:]
+			}
+		}
+
+	case Int:
+		var v int64
+		if v, err = d.Parser.ParseInt(); err == nil {
+			b = strconv.AppendInt(a[:0], v, 10)
+		}
+
+	case Uint:
+		var v uint64
+		if v, err = d.Parser.ParseUint(); err == nil {
+			b = strconv.AppendUint(a[:0], v, 10)
+		}
+
+	case Float:
+		var v float64
+		if v, err = d.Parser.ParseFloat(); err == nil {
+			b = strconv.AppendFloat(a[:0], v, 'g', -1, 64)
+		}
+
+	case Time:
+		var v time.Time
+		if v, err = d.Parser.ParseTime(); err == nil {
+			b = v.AppendFormat(a[:0], time.RFC3339Nano)
+		}
+
+	case Duration:
+		var v time.Duration
+		if v, err = d.Parser.ParseDuration(); err == nil {
+			b = AppendDuration(a[:0], v)
+		}
+
+	case Error:
+		var v error
+		if v, err = d.Parser.ParseError(); err == nil {
+			b = append(a[:0], v.Error()...)
+		}
 
 	default:
 		err = typeConversionError(t, String)

--- a/decode_test.go
+++ b/decode_test.go
@@ -30,6 +30,16 @@ func TestDecoderDecodeType(t *testing.T) {
 		{map[string]int{"answer": 42}, nil},
 		{struct{ A, B, C int }{1, 2, 3}, nil},
 
+		// type -> string (conversion)
+		{true, "true"},
+		{false, "false"},
+		{int(42), "42"},
+		{uint(42), "42"},
+		{float64(0.5), "0.5"},
+		{date, "2016-12-12T01:01:01Z"},
+		{42 * time.Second, "42s"},
+		{err, "error"},
+
 		// nil -> bool
 		{nil, false},
 


### PR DESCRIPTION
@yields 

This is a bit unconventional but I believe it's the right thing to do, I have two motivations for this change:

1. Because the YAML decoder does a two-step work it first loads things in memory so it ends up producing integers in places where the program actually expects to get a string (YAML doesn't really have the notion of ints/string, instead everything is a scalar but the Go decoder still has to chose which types to produce).

2. Taking a very pragmatic approach here, we live in a world where schemas evolve a lot and it's not uncommon for fields to change types from an integer to a string (on purpose or not), I've seen this being a problem at other places before, and I think I can recall at least one time where we had an outage because we changed a data type in an object. So I feel like building tools that are flexible enough to power systems even when humans make mistakes is a good approach.

Feel free to discuss if you have concerns.