### PR TITLE
add support for net, url, and mail types

### DIFF
--- a/encode.go
+++ b/encode.go
@@ -4,6 +4,9 @@ import (
 	"encoding"
 	"fmt"
 	"io"
+	"net"
+	"net/mail"
+	"net/url"
 	"reflect"
 	"time"
 )
@@ -221,6 +224,35 @@ func (e Encoder) encodeDuration(v reflect.Value) error {
 
 func (e Encoder) encodeError(v reflect.Value) error {
 	return e.Emitter.EmitError(v.Interface().(error))
+}
+
+func (e Encoder) encodeTCPAddr(v reflect.Value) error {
+	a := v.Interface().(net.TCPAddr)
+	return e.Emitter.EmitString(a.String())
+}
+
+func (e Encoder) encodeUDPAddr(v reflect.Value) error {
+	a := v.Interface().(net.UDPAddr)
+	return e.Emitter.EmitString(a.String())
+}
+
+func (e Encoder) encodeIPAddr(v reflect.Value) error {
+	a := v.Interface().(net.IPAddr)
+	return e.Emitter.EmitString(a.String())
+}
+
+func (e Encoder) encodeIP(v reflect.Value) error {
+	return e.Emitter.EmitString(v.Interface().(net.IP).String())
+}
+
+func (e Encoder) encodeURL(v reflect.Value) error {
+	u := v.Interface().(url.URL)
+	return e.Emitter.EmitString(u.String())
+}
+
+func (e Encoder) encodeEmail(v reflect.Value) error {
+	a := v.Interface().(mail.Address)
+	return e.Emitter.EmitString(a.String())
 }
 
 func (e Encoder) encodeArray(v reflect.Value) error {
@@ -728,6 +760,24 @@ func makeEncodeFunc(t reflect.Type, opts encodeFuncOpts) encodeFunc {
 
 	case float64Type:
 		return Encoder.encodeFloat64
+
+	case netTCPAddrType:
+		return Encoder.encodeTCPAddr
+
+	case netUDPAddrType:
+		return Encoder.encodeUDPAddr
+
+	case netIPAddrType:
+		return Encoder.encodeIPAddr
+
+	case netIPType:
+		return Encoder.encodeIP
+
+	case urlURLType:
+		return Encoder.encodeURL
+
+	case mailAddressType:
+		return Encoder.encodeEmail
 	}
 
 	switch {

--- a/encode_test.go
+++ b/encode_test.go
@@ -3,6 +3,9 @@ package objconv
 import (
 	"errors"
 	"fmt"
+	"net"
+	"net/mail"
+	"net/url"
 	"reflect"
 	"testing"
 	"time"
@@ -29,6 +32,14 @@ type TBytes []byte
 func TestEncoder(t *testing.T) {
 	now := time.Now()
 	err := errors.New("error")
+
+	ip := net.ParseIP("::1")
+	ipAddr := net.IPAddr{IP: ip, Zone: "zone"}
+	tcpAddr := net.TCPAddr{IP: ip, Port: 4242, Zone: "zone"}
+	udpAddr := net.UDPAddr{IP: ip, Port: 4242, Zone: "zone"}
+
+	location, _ := url.Parse("http://localhost:4242/hello/world?answer=42#question")
+	email, _ := mail.ParseAddress("git@github.com")
 
 	tests := [...]struct {
 		in  interface{}
@@ -91,6 +102,18 @@ func TestEncoder(t *testing.T) {
 
 		// error
 		{err, err},
+
+		// net
+		{ip, "::1"},
+		{ipAddr, "::1%zone"},
+		{tcpAddr, "[::1%zone]:4242"},
+		{udpAddr, "[::1%zone]:4242"},
+
+		// url
+		{location, "http://localhost:4242/hello/world?answer=42#question"},
+
+		// email
+		{email, "<git@github.com>"},
 
 		// array
 		{[...]int{1, 2, 3}, []interface{}{int64(1), int64(2), int64(3)}},

--- a/objtests/test_codec.go
+++ b/objtests/test_codec.go
@@ -5,6 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/mail"
+	"net/url"
 	"reflect"
 	"strconv"
 	"strings"
@@ -124,6 +127,29 @@ var TestValues = [...]interface{}{
 		T time.Time
 		S string
 	}{42, time.Date(2016, 12, 20, 0, 20, 1, 0, time.UTC), "Hello World!"},
+
+	// net
+	net.TCPAddr{
+		IP:   net.ParseIP("::1"),
+		Port: 4242,
+		Zone: "zone",
+	},
+	net.UDPAddr{
+		IP:   net.ParseIP("::1"),
+		Port: 4242,
+		Zone: "zone",
+	},
+	net.IPAddr{
+		IP:   net.ParseIP("::1"),
+		Zone: "zone",
+	},
+	net.IPv4(127, 0, 0, 1),
+
+	// url
+	parseURL("http://localhost:4242/hello/world?answer=42#question"),
+
+	// mail
+	parseEmail("git@github.com"),
 }
 
 func makeMap(n int) map[string]string {
@@ -339,4 +365,14 @@ func benchmarkStreamDecoder(b *testing.B, codec objconv.Codec) {
 
 		a.Reset()
 	}
+}
+
+func parseURL(s string) url.URL {
+	u, _ := url.Parse(s)
+	return *u
+}
+
+func parseEmail(s string) mail.Address {
+	a, _ := mail.ParseAddress(s)
+	return *a
 }

--- a/parse.go
+++ b/parse.go
@@ -3,7 +3,10 @@ package objconv
 import (
 	"errors"
 	"fmt"
+	"net"
 	"reflect"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -505,6 +508,34 @@ func ParseUintHex(b []byte) (uint64, error) {
 	}
 
 	return val, nil
+}
+
+func parseNetAddr(s string) (ip net.IP, port int, zone string, err error) {
+	var h string
+	var p string
+
+	if h, p, err = net.SplitHostPort(s); err != nil {
+		h, p = s, ""
+	}
+
+	if len(h) != 0 {
+		if off := strings.IndexByte(h, '%'); off >= 0 {
+			h, zone = h[:off], h[off+1:]
+		}
+		if ip = net.ParseIP(h); ip == nil {
+			err = errors.New("objconv: bad IP address: " + s)
+			return
+		}
+	}
+
+	if len(p) != 0 {
+		if port, err = strconv.Atoi(p); err != nil || port < 0 || port > 65535 {
+			err = errors.New("objconv: bad port number: " + s)
+			return
+		}
+	}
+
+	return
 }
 
 func errorInvalidInt64(b []byte) error {

--- a/value.go
+++ b/value.go
@@ -2,6 +2,9 @@ package objconv
 
 import (
 	"encoding"
+	"net"
+	"net/mail"
+	"net/url"
 	"reflect"
 	"sync"
 	"time"
@@ -189,20 +192,31 @@ var (
 	durationType       = reflect.TypeOf(time.Duration(0))
 	sliceInterfaceType = reflect.TypeOf(([]interface{})(nil))
 	timePtrType        = reflect.PtrTo(timeType)
+	netTCPAddrType     = reflect.TypeOf(net.TCPAddr{})
+	netUDPAddrType     = reflect.TypeOf(net.UDPAddr{})
+	netUnixAddrType    = reflect.TypeOf(net.UnixAddr{})
+	netIPAddrType      = reflect.TypeOf(net.IPAddr{})
+	netIPType          = reflect.TypeOf(net.IP(nil))
+	urlURLType         = reflect.TypeOf(url.URL{})
+	mailAddressType    = reflect.TypeOf(mail.Address{})
 
 	// interfaces
-	errorInterface           = reflect.TypeOf((*error)(nil)).Elem()
-	valueEncoderInterface    = reflect.TypeOf((*ValueEncoder)(nil)).Elem()
-	valueDecoderInterface    = reflect.TypeOf((*ValueDecoder)(nil)).Elem()
-	textMarshalerInterface   = reflect.TypeOf((*encoding.TextMarshaler)(nil)).Elem()
-	textUnmarshalerInterface = reflect.TypeOf((*encoding.TextUnmarshaler)(nil)).Elem()
-	emptyInterface           = reflect.TypeOf((*interface{})(nil)).Elem()
+	errorInterface           = elemTypeOf((*error)(nil))
+	valueEncoderInterface    = elemTypeOf((*ValueEncoder)(nil))
+	valueDecoderInterface    = elemTypeOf((*ValueDecoder)(nil))
+	textMarshalerInterface   = elemTypeOf((*encoding.TextMarshaler)(nil))
+	textUnmarshalerInterface = elemTypeOf((*encoding.TextUnmarshaler)(nil))
+	emptyInterface           = elemTypeOf((*interface{})(nil))
 
 	// common map types, used for optimization for map encoding algorithms
 	mapStringStringType       = reflect.TypeOf((map[string]string)(nil))
 	mapStringInterfaceType    = reflect.TypeOf((map[string]interface{})(nil))
 	mapInterfaceInterfaceType = reflect.TypeOf((map[interface{}]interface{})(nil))
 )
+
+func elemTypeOf(v interface{}) reflect.Type {
+	return reflect.TypeOf(v).Elem()
+}
 
 func stringNoCopy(b []byte) string {
 	n := len(b)


### PR DESCRIPTION
@yields 
@f2prateek 

This PR adds out-of-the-box support for more standard types, making it possible to write code like this:
```go
var a net.TCPAddr

json.Unmarshal([]byte(`"192.168.0.1:80"`), &a)

// a.IP   == net.IPv4(192, 168, 0, 1)
// a.Port == 80
```

My motivations behind this changes are:
1. We cannot modify the standard library types to make them implement `encoding.TextMarshaler` or `objconv.ValueEncoder`
2. I'd like to provide support for these types in github.com/segmentio/conf without having to write custom code in that package (we get it for free if it's in objconv)

Please take a look and let me know if anything should be changed.