### PR TITLE
add adapters

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -1,0 +1,55 @@
+package objconv
+
+import (
+	"reflect"
+	"sync"
+)
+
+// An Adapter is a pair of an encoder and a decoder function that can be
+// installed on the package to support new types.
+type Adapter struct {
+	Encode func(Encoder, reflect.Value) error
+	Decode func(Decoder, reflect.Value) error
+}
+
+// Install adds an adapter for typ.
+//
+// The function panics if one of the encoder and decoder functions of the
+// adapter are nil.
+//
+// A typical use case for this function is to be called during the package
+// initialization phase to extend objconv support for new types.
+func Install(typ reflect.Type, adapter Adapter) {
+	if adapter.Encode == nil {
+		panic("objconv: the encoder function of an adapter cannot be nil")
+	}
+
+	if adapter.Decode == nil {
+		panic("objconv: the decoder function of an adapter cannot be nil")
+	}
+
+	adapterMutex.Lock()
+	adapterStore[typ] = adapter
+	adapterMutex.Unlock()
+
+	// We have to clear the struct cache because it may now have become invalid.
+	// Because installing adapters is done in the package initialization phase
+	// it's unlikely that any encoding or decoding operations are taking place
+	// at this time so there should be no performance impact of clearing the
+	// cache.
+	structCache.clear()
+}
+
+// adapterOf returns the adapter for typ, setting ok to true if one was found,
+// false otherwise.
+func adapterOf(typ reflect.Type) (a Adapter, ok bool) {
+	adapterMutex.RLock()
+	a, ok = adapterStore[typ]
+	adapterMutex.RUnlock()
+	return
+}
+
+var (
+	adapterMutex sync.RWMutex
+	adapterStore = make(map[reflect.Type]Adapter)
+)

--- a/adapter.go
+++ b/adapter.go
@@ -40,9 +40,9 @@ func Install(typ reflect.Type, adapter Adapter) {
 	structCache.clear()
 }
 
-// adapterOf returns the adapter for typ, setting ok to true if one was found,
+// AdapterOf returns the adapter for typ, setting ok to true if one was found,
 // false otherwise.
-func adapterOf(typ reflect.Type) (a Adapter, ok bool) {
+func AdapterOf(typ reflect.Type) (a Adapter, ok bool) {
 	adapterMutex.RLock()
 	a, ok = adapterStore[typ]
 	adapterMutex.RUnlock()

--- a/adapters/doc.go
+++ b/adapters/doc.go
@@ -1,0 +1,12 @@
+// Package adapters installs all adapters from its subpackages into the objconv
+// package.
+//
+// This package exposes no functions or types and is solely useful for the side
+// effect of setting up extra adapters on the objconv package on initialization.
+package adapters
+
+import (
+	_ "github.com/segmentio/objconv/adapters/net"
+	_ "github.com/segmentio/objconv/adapters/net/mail"
+	_ "github.com/segmentio/objconv/adapters/net/url"
+)

--- a/adapters/net/decode.go
+++ b/adapters/net/decode.go
@@ -1,0 +1,147 @@
+package net
+
+import (
+	"errors"
+	"net"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/segmentio/objconv"
+)
+
+// DecodeTCPAddr decodes a net.TCPAddr value into to from a string
+// representation using d.
+func DecodeTCPAddr(d objconv.Decoder, to reflect.Value) (err error) {
+	var a net.TCPAddr
+	var s string
+
+	if err = d.Decode(&s); err != nil {
+		return
+	}
+
+	if a.IP, a.Port, a.Zone, err = parseNetAddr(s); err != nil {
+		return
+	}
+
+	if to.IsValid() {
+		to.Set(reflect.ValueOf(a))
+	}
+	return
+}
+
+// DecodeUDPAddr decodes a net.UDPAddr value into to from a string
+// representation using d.
+func DecodeUDPAddr(d objconv.Decoder, to reflect.Value) (err error) {
+	var a net.UDPAddr
+	var s string
+
+	if err = d.Decode(&s); err != nil {
+		return
+	}
+
+	if a.IP, a.Port, a.Zone, err = parseNetAddr(s); err != nil {
+		return
+	}
+
+	if to.IsValid() {
+		to.Set(reflect.ValueOf(a))
+	}
+	return
+}
+
+// DecodeUNIXAddr decodes a net.UNIXAddr value into to from a string
+// representation using d.
+func DecodeUnixAddr(d objconv.Decoder, to reflect.Value) (err error) {
+	var a net.UnixAddr
+	var s string
+
+	if err = d.Decode(&s); err != nil {
+		return
+	}
+
+	if i := strings.Index(s, "://"); i >= 0 {
+		a.Net, a.Name = s[:i], s[i+3:]
+	} else {
+		a.Net, a.Name = "unix", s
+	}
+
+	if to.IsValid() {
+		to.Set(reflect.ValueOf(a))
+	}
+	return
+}
+
+// DecodeIPAddr decodes a net.IPAddr value into to from a string
+// representation using d.
+func DecodeIPAddr(d objconv.Decoder, to reflect.Value) (err error) {
+	var a net.IPAddr
+	var s string
+
+	if err = d.Decode(&s); err != nil {
+		return
+	}
+
+	if i := strings.IndexByte(s, '%'); i >= 0 {
+		s, a.Zone = s[:i], s[i+1:]
+	}
+
+	if a.IP = net.ParseIP(s); a.IP == nil {
+		err = errors.New("objconv: bad IP adress: " + s)
+		return
+	}
+
+	if to.IsValid() {
+		to.Set(reflect.ValueOf(a))
+	}
+	return
+}
+
+// DecodeIP decodes a net.IP value into to from a string representation
+// using d.
+func DecodeIP(d objconv.Decoder, to reflect.Value) (err error) {
+	var ip net.IP
+	var s string
+
+	if err = d.Decode(&s); err != nil {
+		return
+	}
+
+	if ip = net.ParseIP(s); ip == nil {
+		err = errors.New("objconv: bad IP address: " + s)
+		return
+	}
+
+	if to.IsValid() {
+		to.Set(reflect.ValueOf(ip))
+	}
+	return
+}
+
+func parseNetAddr(s string) (ip net.IP, port int, zone string, err error) {
+	var h string
+	var p string
+
+	if h, p, err = net.SplitHostPort(s); err != nil {
+		h, p = s, ""
+	}
+
+	if len(h) != 0 {
+		if off := strings.IndexByte(h, '%'); off >= 0 {
+			h, zone = h[:off], h[off+1:]
+		}
+		if ip = net.ParseIP(h); ip == nil {
+			err = errors.New("objconv: bad IP address: " + s)
+			return
+		}
+	}
+
+	if len(p) != 0 {
+		if port, err = strconv.Atoi(p); err != nil || port < 0 || port > 65535 {
+			err = errors.New("objconv: bad port number: " + s)
+			return
+		}
+	}
+
+	return
+}

--- a/adapters/net/decode.go
+++ b/adapters/net/decode.go
@@ -10,9 +10,7 @@ import (
 	"github.com/segmentio/objconv"
 )
 
-// DecodeTCPAddr decodes a net.TCPAddr value into to from a string
-// representation using d.
-func DecodeTCPAddr(d objconv.Decoder, to reflect.Value) (err error) {
+func decodeTCPAddr(d objconv.Decoder, to reflect.Value) (err error) {
 	var a net.TCPAddr
 	var s string
 
@@ -30,9 +28,7 @@ func DecodeTCPAddr(d objconv.Decoder, to reflect.Value) (err error) {
 	return
 }
 
-// DecodeUDPAddr decodes a net.UDPAddr value into to from a string
-// representation using d.
-func DecodeUDPAddr(d objconv.Decoder, to reflect.Value) (err error) {
+func decodeUDPAddr(d objconv.Decoder, to reflect.Value) (err error) {
 	var a net.UDPAddr
 	var s string
 
@@ -50,9 +46,7 @@ func DecodeUDPAddr(d objconv.Decoder, to reflect.Value) (err error) {
 	return
 }
 
-// DecodeUNIXAddr decodes a net.UNIXAddr value into to from a string
-// representation using d.
-func DecodeUnixAddr(d objconv.Decoder, to reflect.Value) (err error) {
+func decodeUnixAddr(d objconv.Decoder, to reflect.Value) (err error) {
 	var a net.UnixAddr
 	var s string
 
@@ -72,9 +66,7 @@ func DecodeUnixAddr(d objconv.Decoder, to reflect.Value) (err error) {
 	return
 }
 
-// DecodeIPAddr decodes a net.IPAddr value into to from a string
-// representation using d.
-func DecodeIPAddr(d objconv.Decoder, to reflect.Value) (err error) {
+func decodeIPAddr(d objconv.Decoder, to reflect.Value) (err error) {
 	var a net.IPAddr
 	var s string
 
@@ -97,9 +89,7 @@ func DecodeIPAddr(d objconv.Decoder, to reflect.Value) (err error) {
 	return
 }
 
-// DecodeIP decodes a net.IP value into to from a string representation
-// using d.
-func DecodeIP(d objconv.Decoder, to reflect.Value) (err error) {
+func decodeIP(d objconv.Decoder, to reflect.Value) (err error) {
 	var ip net.IP
 	var s string
 

--- a/adapters/net/doc.go
+++ b/adapters/net/doc.go
@@ -1,0 +1,5 @@
+// Package net provides adapters for types in the standard net package.
+//
+// The types and functions in this package aren't usually used direction and
+// instead are used implicitly by installing adapters on objconv.
+package net

--- a/adapters/net/encode.go
+++ b/adapters/net/encode.go
@@ -7,32 +7,27 @@ import (
 	"github.com/segmentio/objconv"
 )
 
-// EncodeTCPAddr encodes the net.TCPAddr value in v as a string using e.
-func EncodeTCPAddr(e objconv.Encoder, v reflect.Value) error {
+func encodeTCPAddr(e objconv.Encoder, v reflect.Value) error {
 	a := v.Interface().(net.TCPAddr)
 	return e.Emitter.EmitString(a.String())
 }
 
-// EncodeUDPAddr encodes the net.UDPAddr value in v as a string using e.
-func EncodeUDPAddr(e objconv.Encoder, v reflect.Value) error {
+func encodeUDPAddr(e objconv.Encoder, v reflect.Value) error {
 	a := v.Interface().(net.UDPAddr)
 	return e.Emitter.EmitString(a.String())
 }
 
-// EncodeUnixAddr encodes the net.UnixAddr value in v as a string using e.
-func EncodeUnixAddr(e objconv.Encoder, v reflect.Value) error {
+func encodeUnixAddr(e objconv.Encoder, v reflect.Value) error {
 	a := v.Interface().(net.UnixAddr)
 	return e.Emitter.EmitString(a.String())
 }
 
-// EncodeIPAddr encodes the net.IPAddr value in v as a string using e.
-func EncodeIPAddr(e objconv.Encoder, v reflect.Value) error {
+func encodeIPAddr(e objconv.Encoder, v reflect.Value) error {
 	a := v.Interface().(net.IPAddr)
 	return e.Emitter.EmitString(a.String())
 }
 
-// EncodeIP encodes the net.IP value in v as a string using e.
-func EncodeIP(e objconv.Encoder, v reflect.Value) error {
+func encodeIP(e objconv.Encoder, v reflect.Value) error {
 	a := v.Interface().(net.IP)
 	return e.Emitter.EmitString(a.String())
 }

--- a/adapters/net/encode.go
+++ b/adapters/net/encode.go
@@ -1,0 +1,38 @@
+package net
+
+import (
+	"net"
+	"reflect"
+
+	"github.com/segmentio/objconv"
+)
+
+// EncodeTCPAddr encodes the net.TCPAddr value in v as a string using e.
+func EncodeTCPAddr(e objconv.Encoder, v reflect.Value) error {
+	a := v.Interface().(net.TCPAddr)
+	return e.Emitter.EmitString(a.String())
+}
+
+// EncodeUDPAddr encodes the net.UDPAddr value in v as a string using e.
+func EncodeUDPAddr(e objconv.Encoder, v reflect.Value) error {
+	a := v.Interface().(net.UDPAddr)
+	return e.Emitter.EmitString(a.String())
+}
+
+// EncodeUnixAddr encodes the net.UnixAddr value in v as a string using e.
+func EncodeUnixAddr(e objconv.Encoder, v reflect.Value) error {
+	a := v.Interface().(net.UnixAddr)
+	return e.Emitter.EmitString(a.String())
+}
+
+// EncodeIPAddr encodes the net.IPAddr value in v as a string using e.
+func EncodeIPAddr(e objconv.Encoder, v reflect.Value) error {
+	a := v.Interface().(net.IPAddr)
+	return e.Emitter.EmitString(a.String())
+}
+
+// EncodeIP encodes the net.IP value in v as a string using e.
+func EncodeIP(e objconv.Encoder, v reflect.Value) error {
+	a := v.Interface().(net.IP)
+	return e.Emitter.EmitString(a.String())
+}

--- a/adapters/net/init.go
+++ b/adapters/net/init.go
@@ -1,0 +1,35 @@
+package net
+
+import (
+	"net"
+	"reflect"
+
+	"github.com/segmentio/objconv"
+)
+
+func init() {
+	objconv.Install(reflect.TypeOf(net.TCPAddr{}), objconv.Adapter{
+		Encode: EncodeTCPAddr,
+		Decode: DecodeTCPAddr,
+	})
+
+	objconv.Install(reflect.TypeOf(net.UDPAddr{}), objconv.Adapter{
+		Encode: EncodeUDPAddr,
+		Decode: DecodeUDPAddr,
+	})
+
+	objconv.Install(reflect.TypeOf(net.UnixAddr{}), objconv.Adapter{
+		Encode: EncodeUnixAddr,
+		Decode: DecodeUnixAddr,
+	})
+
+	objconv.Install(reflect.TypeOf(net.IPAddr{}), objconv.Adapter{
+		Encode: EncodeIPAddr,
+		Decode: DecodeIPAddr,
+	})
+
+	objconv.Install(reflect.TypeOf(net.IP(nil)), objconv.Adapter{
+		Encode: EncodeIP,
+		Decode: DecodeIP,
+	})
+}

--- a/adapters/net/init.go
+++ b/adapters/net/init.go
@@ -8,28 +8,49 @@ import (
 )
 
 func init() {
-	objconv.Install(reflect.TypeOf(net.TCPAddr{}), objconv.Adapter{
-		Encode: EncodeTCPAddr,
-		Decode: DecodeTCPAddr,
-	})
+	objconv.Install(reflect.TypeOf(net.TCPAddr{}), TCPAddrAdapter())
+	objconv.Install(reflect.TypeOf(net.UDPAddr{}), UDPAddrAdapter())
+	objconv.Install(reflect.TypeOf(net.UnixAddr{}), UnixAddrAdapter())
+	objconv.Install(reflect.TypeOf(net.IPAddr{}), IPAddrAdapter())
+	objconv.Install(reflect.TypeOf(net.IP(nil)), IPAdapter())
+}
 
-	objconv.Install(reflect.TypeOf(net.UDPAddr{}), objconv.Adapter{
-		Encode: EncodeUDPAddr,
-		Decode: DecodeUDPAddr,
-	})
+// TCPAddrAdapter returns the adapter to encode and decode net.TCPAddr values.
+func TCPAddrAdapter() objconv.Adapter {
+	return objconv.Adapter{
+		Encode: encodeTCPAddr,
+		Decode: decodeTCPAddr,
+	}
+}
 
-	objconv.Install(reflect.TypeOf(net.UnixAddr{}), objconv.Adapter{
-		Encode: EncodeUnixAddr,
-		Decode: DecodeUnixAddr,
-	})
+// UDPAddrAdapter returns the adapter to encode and decode net.UDPAddr values.
+func UDPAddrAdapter() objconv.Adapter {
+	return objconv.Adapter{
+		Encode: encodeUDPAddr,
+		Decode: decodeUDPAddr,
+	}
+}
 
-	objconv.Install(reflect.TypeOf(net.IPAddr{}), objconv.Adapter{
-		Encode: EncodeIPAddr,
-		Decode: DecodeIPAddr,
-	})
+// UnixAddrAdapter returns the adapter to encode and decode net.UnixAddr values.
+func UnixAddrAdapter() objconv.Adapter {
+	return objconv.Adapter{
+		Encode: encodeUnixAddr,
+		Decode: decodeUnixAddr,
+	}
+}
 
-	objconv.Install(reflect.TypeOf(net.IP(nil)), objconv.Adapter{
-		Encode: EncodeIP,
-		Decode: DecodeIP,
-	})
+// IPAddrAdapter returns the adapter to encode and decode net.IPAddr values.
+func IPAddrAdapter() objconv.Adapter {
+	return objconv.Adapter{
+		Encode: encodeIPAddr,
+		Decode: decodeIPAddr,
+	}
+}
+
+// IPAdapter returns the adapter to encode and decode net.IP values.
+func IPAdapter() objconv.Adapter {
+	return objconv.Adapter{
+		Encode: encodeIP,
+		Decode: decodeIP,
+	}
 }

--- a/adapters/net/mail/decode.go
+++ b/adapters/net/mail/decode.go
@@ -26,3 +26,22 @@ func decodeAddress(d objconv.Decoder, to reflect.Value) (err error) {
 	}
 	return
 }
+
+func decodeAddressList(d objconv.Decoder, to reflect.Value) (err error) {
+	var l []*mail.Address
+	var s string
+
+	if err = d.Decode(&s); err != nil {
+		return
+	}
+
+	if l, err = mail.ParseAddressList(s); err != nil {
+		err = errors.New("objconv: bad email address list: " + err.Error())
+		return
+	}
+
+	if to.IsValid() {
+		to.Set(reflect.ValueOf(l))
+	}
+	return
+}

--- a/adapters/net/mail/decode.go
+++ b/adapters/net/mail/decode.go
@@ -1,0 +1,30 @@
+package mail
+
+import (
+	"errors"
+	"net/mail"
+	"reflect"
+
+	"github.com/segmentio/objconv"
+)
+
+// DecodeAddress decodes a mail.Address value into to from a string
+// representation using d.
+func DecodeAddress(d objconv.Decoder, to reflect.Value) (err error) {
+	var a *mail.Address
+	var s string
+
+	if err = d.Decode(&s); err != nil {
+		return
+	}
+
+	if a, err = mail.ParseAddress(s); err != nil {
+		err = errors.New("objconv: bad email address: " + err.Error())
+		return
+	}
+
+	if to.IsValid() {
+		to.Set(reflect.ValueOf(*a))
+	}
+	return
+}

--- a/adapters/net/mail/decode.go
+++ b/adapters/net/mail/decode.go
@@ -8,9 +8,7 @@ import (
 	"github.com/segmentio/objconv"
 )
 
-// DecodeAddress decodes a mail.Address value into to from a string
-// representation using d.
-func DecodeAddress(d objconv.Decoder, to reflect.Value) (err error) {
+func decodeAddress(d objconv.Decoder, to reflect.Value) (err error) {
 	var a *mail.Address
 	var s string
 

--- a/adapters/net/mail/doc.go
+++ b/adapters/net/mail/doc.go
@@ -1,0 +1,5 @@
+// Package mail provides adapters for types in the standard net/mail package.
+//
+// The types and functions in this package aren't usually used direction and
+// instead are used implicitly by installing adapters on objconv.
+package mail

--- a/adapters/net/mail/encode.go
+++ b/adapters/net/mail/encode.go
@@ -1,0 +1,14 @@
+package mail
+
+import (
+	"net/mail"
+	"reflect"
+
+	"github.com/segmentio/objconv"
+)
+
+// EncodeAddress encodes the mail.Address value in v as a string using e.
+func EncodeAddress(e objconv.Encoder, v reflect.Value) error {
+	a := v.Interface().(mail.Address)
+	return e.Emitter.EmitString(a.String())
+}

--- a/adapters/net/mail/encode.go
+++ b/adapters/net/mail/encode.go
@@ -1,6 +1,7 @@
 package mail
 
 import (
+	"bytes"
 	"net/mail"
 	"reflect"
 
@@ -10,4 +11,21 @@ import (
 func encodeAddress(e objconv.Encoder, v reflect.Value) error {
 	a := v.Interface().(mail.Address)
 	return e.Emitter.EmitString(a.String())
+}
+
+func encodeAddressList(e objconv.Encoder, v reflect.Value) error {
+	l := v.Interface().([]*mail.Address)
+	b := &bytes.Buffer{}
+
+	for i, a := range l {
+		if a == nil {
+			continue
+		}
+		if i != 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(a.String())
+	}
+
+	return e.EncodeString(b.String())
 }

--- a/adapters/net/mail/encode.go
+++ b/adapters/net/mail/encode.go
@@ -7,8 +7,7 @@ import (
 	"github.com/segmentio/objconv"
 )
 
-// EncodeAddress encodes the mail.Address value in v as a string using e.
-func EncodeAddress(e objconv.Encoder, v reflect.Value) error {
+func encodeAddress(e objconv.Encoder, v reflect.Value) error {
 	a := v.Interface().(mail.Address)
 	return e.Emitter.EmitString(a.String())
 }

--- a/adapters/net/mail/init.go
+++ b/adapters/net/mail/init.go
@@ -1,0 +1,15 @@
+package mail
+
+import (
+	"net/mail"
+	"reflect"
+
+	"github.com/segmentio/objconv"
+)
+
+func init() {
+	objconv.Install(reflect.TypeOf(mail.Address{}), objconv.Adapter{
+		Encode: EncodeAddress,
+		Decode: DecodeAddress,
+	})
+}

--- a/adapters/net/mail/init.go
+++ b/adapters/net/mail/init.go
@@ -22,6 +22,10 @@ func AddressAdapter() objconv.Adapter {
 
 // AddressListAdapter returns the adapter to encode and decode []*mail.Address
 // values.
+//
+// The adapter uses a string representation of the mail address list, in cases
+// where the serialized form has to be an actual array of strings the program
+// should use []mail.Address (no pointers).
 func AddressListAdapter() objconv.Adapter {
 	return objconv.Adapter{
 		Encode: encodeAddressList,

--- a/adapters/net/mail/init.go
+++ b/adapters/net/mail/init.go
@@ -9,6 +9,7 @@ import (
 
 func init() {
 	objconv.Install(reflect.TypeOf(mail.Address{}), AddressAdapter())
+	objconv.Install(reflect.TypeOf(([]*mail.Address)(nil)), AddressListAdapter())
 }
 
 // AddressAdapter returns the adapter to encode and decode mail.Address values.
@@ -16,5 +17,14 @@ func AddressAdapter() objconv.Adapter {
 	return objconv.Adapter{
 		Encode: encodeAddress,
 		Decode: decodeAddress,
+	}
+}
+
+// AddressListAdapter returns the adapter to encode and decode []*mail.Address
+// values.
+func AddressListAdapter() objconv.Adapter {
+	return objconv.Adapter{
+		Encode: encodeAddressList,
+		Decode: decodeAddressList,
 	}
 }

--- a/adapters/net/mail/init.go
+++ b/adapters/net/mail/init.go
@@ -8,8 +8,13 @@ import (
 )
 
 func init() {
-	objconv.Install(reflect.TypeOf(mail.Address{}), objconv.Adapter{
-		Encode: EncodeAddress,
-		Decode: DecodeAddress,
-	})
+	objconv.Install(reflect.TypeOf(mail.Address{}), AddressAdapter())
+}
+
+// AddressAdapter returns the adapter to encode and decode mail.Address values.
+func AddressAdapter() objconv.Adapter {
+	return objconv.Adapter{
+		Encode: encodeAddress,
+		Decode: decodeAddress,
+	}
 }

--- a/adapters/net/url/decode.go
+++ b/adapters/net/url/decode.go
@@ -1,0 +1,30 @@
+package url
+
+import (
+	"errors"
+	"net/url"
+	"reflect"
+
+	"github.com/segmentio/objconv"
+)
+
+// DecodeURL decodes a url.URL value into to from a string representation
+// using d.
+func DecodeURL(d objconv.Decoder, to reflect.Value) (err error) {
+	var u *url.URL
+	var s string
+
+	if err = d.Decode(&s); err != nil {
+		return
+	}
+
+	if u, err = url.Parse(s); err != nil {
+		err = errors.New("objconv: bad URL: " + err.Error())
+		return
+	}
+
+	if to.IsValid() {
+		to.Set(reflect.ValueOf(*u))
+	}
+	return
+}

--- a/adapters/net/url/decode.go
+++ b/adapters/net/url/decode.go
@@ -26,3 +26,22 @@ func decodeURL(d objconv.Decoder, to reflect.Value) (err error) {
 	}
 	return
 }
+
+func decodeQuery(d objconv.Decoder, to reflect.Value) (err error) {
+	var v url.Values
+	var s string
+
+	if err = d.Decode(&s); err != nil {
+
+	}
+
+	if v, err = url.ParseQuery(s); err != nil {
+		err = errors.New("objconv: bad URL values: " + err.Error())
+		return
+	}
+
+	if to.IsValid() {
+		to.Set(reflect.ValueOf(v))
+	}
+	return
+}

--- a/adapters/net/url/decode.go
+++ b/adapters/net/url/decode.go
@@ -8,9 +8,7 @@ import (
 	"github.com/segmentio/objconv"
 )
 
-// DecodeURL decodes a url.URL value into to from a string representation
-// using d.
-func DecodeURL(d objconv.Decoder, to reflect.Value) (err error) {
+func decodeURL(d objconv.Decoder, to reflect.Value) (err error) {
 	var u *url.URL
 	var s string
 

--- a/adapters/net/url/doc.go
+++ b/adapters/net/url/doc.go
@@ -1,0 +1,5 @@
+// Package url provides adapters for types in the standard net/url package.
+//
+// The types and functions in this package aren't usually used direction and
+// instead are used implicitly by installing adapters on objconv.
+package url

--- a/adapters/net/url/encode.go
+++ b/adapters/net/url/encode.go
@@ -7,8 +7,7 @@ import (
 	"github.com/segmentio/objconv"
 )
 
-// EncodeURL encodes the url.URL value in v as a string using e.
-func EncodeURL(e objconv.Encoder, v reflect.Value) error {
+func encodeURL(e objconv.Encoder, v reflect.Value) error {
 	u := v.Interface().(url.URL)
 	return e.Emitter.EmitString(u.String())
 }

--- a/adapters/net/url/encode.go
+++ b/adapters/net/url/encode.go
@@ -1,0 +1,14 @@
+package url
+
+import (
+	"net/url"
+	"reflect"
+
+	"github.com/segmentio/objconv"
+)
+
+// EncodeURL encodes the url.URL value in v as a string using e.
+func EncodeURL(e objconv.Encoder, v reflect.Value) error {
+	u := v.Interface().(url.URL)
+	return e.Emitter.EmitString(u.String())
+}

--- a/adapters/net/url/encode.go
+++ b/adapters/net/url/encode.go
@@ -11,3 +11,8 @@ func encodeURL(e objconv.Encoder, v reflect.Value) error {
 	u := v.Interface().(url.URL)
 	return e.Emitter.EmitString(u.String())
 }
+
+func encodeQuery(e objconv.Encoder, v reflect.Value) error {
+	q := v.Interface().(url.Values)
+	return e.Emitter.EmitString(q.Encode())
+}

--- a/adapters/net/url/init.go
+++ b/adapters/net/url/init.go
@@ -1,0 +1,15 @@
+package url
+
+import (
+	"net/url"
+	"reflect"
+
+	"github.com/segmentio/objconv"
+)
+
+func init() {
+	objconv.Install(reflect.TypeOf(url.URL{}), objconv.Adapter{
+		Encode: EncodeURL,
+		Decode: DecodeURL,
+	})
+}

--- a/adapters/net/url/init.go
+++ b/adapters/net/url/init.go
@@ -8,8 +8,13 @@ import (
 )
 
 func init() {
-	objconv.Install(reflect.TypeOf(url.URL{}), objconv.Adapter{
-		Encode: EncodeURL,
-		Decode: DecodeURL,
-	})
+	objconv.Install(reflect.TypeOf(url.URL{}), URLAdapter())
+}
+
+// URLAdapter returns the adapter to encode and decode url.URL values.
+func URLAdapter() objconv.Adapter {
+	return objconv.Adapter{
+		Encode: encodeURL,
+		Decode: decodeURL,
+	}
 }

--- a/adapters/net/url/init.go
+++ b/adapters/net/url/init.go
@@ -9,6 +9,7 @@ import (
 
 func init() {
 	objconv.Install(reflect.TypeOf(url.URL{}), URLAdapter())
+	objconv.Install(reflect.TypeOf(url.Values(nil)), QueryAdapter())
 }
 
 // URLAdapter returns the adapter to encode and decode url.URL values.
@@ -16,5 +17,13 @@ func URLAdapter() objconv.Adapter {
 	return objconv.Adapter{
 		Encode: encodeURL,
 		Decode: decodeURL,
+	}
+}
+
+// QueryAdapter returns the adapter to encode and decode url.Values values.
+func QueryAdapter() objconv.Adapter {
+	return objconv.Adapter{
+		Encode: encodeQuery,
+		Decode: decodeQuery,
 	}
 }

--- a/decode.go
+++ b/decode.go
@@ -4,12 +4,8 @@ import (
 	"encoding"
 	"errors"
 	"fmt"
-	"net"
-	"net/mail"
-	"net/url"
 	"reflect"
 	"strconv"
-	"strings"
 	"time"
 )
 
@@ -524,146 +520,6 @@ func (d Decoder) decodeErrorFromType(t Type, to reflect.Value) (err error) {
 	return
 }
 
-func (d Decoder) decodeTCPAddr(to reflect.Value) (t Type, err error) {
-	var a net.TCPAddr
-	var b []byte
-
-	if t, b, err = d.decodeTypeAndString(); err != nil {
-		return
-	}
-
-	if a.IP, a.Port, a.Zone, err = parseNetAddr(string(b)); err != nil {
-		return
-	}
-
-	if to.IsValid() {
-		to.Set(reflect.ValueOf(a))
-	}
-	return
-}
-
-func (d Decoder) decodeUDPAddr(to reflect.Value) (t Type, err error) {
-	var a net.UDPAddr
-	var b []byte
-
-	if t, b, err = d.decodeTypeAndString(); err != nil {
-		return
-	}
-
-	if a.IP, a.Port, a.Zone, err = parseNetAddr(string(b)); err != nil {
-		return
-	}
-
-	if to.IsValid() {
-		to.Set(reflect.ValueOf(a))
-	}
-	return
-}
-
-func (d Decoder) decodeUnixAddr(to reflect.Value) (t Type, err error) {
-	var a net.UnixAddr
-	var b []byte
-
-	if t, b, err = d.decodeTypeAndString(); err != nil {
-		return
-	}
-
-	s := string(b)
-
-	if i := strings.Index(s, "://"); i >= 0 {
-		a.Net, a.Name = s[:i], s[i+3:]
-	} else {
-		a.Net, a.Name = "unix", s
-	}
-
-	if to.IsValid() {
-		to.Set(reflect.ValueOf(a))
-	}
-	return
-}
-
-func (d Decoder) decodeIPAddr(to reflect.Value) (t Type, err error) {
-	var a net.IPAddr
-	var b []byte
-
-	if t, b, err = d.decodeTypeAndString(); err != nil {
-		return
-	}
-
-	s := string(b)
-
-	if i := strings.IndexByte(s, '%'); i >= 0 {
-		s, a.Zone = s[:i], s[i+1:]
-	}
-
-	if a.IP = net.ParseIP(s); a.IP == nil {
-		err = errors.New("objconv: bad IP adress: " + string(b))
-		return
-	}
-
-	if to.IsValid() {
-		to.Set(reflect.ValueOf(a))
-	}
-	return
-}
-
-func (d Decoder) decodeIP(to reflect.Value) (t Type, err error) {
-	var ip net.IP
-	var b []byte
-
-	if t, b, err = d.decodeTypeAndString(); err != nil {
-		return
-	}
-
-	if ip = net.ParseIP(string(b)); ip == nil {
-		err = errors.New("objconv: bad IP address: " + string(b))
-		return
-	}
-
-	if to.IsValid() {
-		to.Set(reflect.ValueOf(ip))
-	}
-	return
-}
-
-func (d Decoder) decodeURL(to reflect.Value) (t Type, err error) {
-	var u *url.URL
-	var b []byte
-
-	if t, b, err = d.decodeTypeAndString(); err != nil {
-		return
-	}
-
-	if u, err = url.Parse(string(b)); err != nil {
-		err = errors.New("objconv: bad URL: " + err.Error())
-		return
-	}
-
-	if to.IsValid() {
-		to.Set(reflect.ValueOf(*u))
-	}
-	return
-}
-
-func (d Decoder) decodeEmail(to reflect.Value) (t Type, err error) {
-	var a *mail.Address
-	var b []byte
-
-	if t, b, err = d.decodeTypeAndString(); err != nil {
-		return
-	}
-
-	if a, err = mail.ParseAddress(string(b)); err != nil {
-		err = errors.New("objconv: bad email address: " + err.Error())
-		return
-	}
-
-	if to.IsValid() {
-		to.Set(reflect.ValueOf(*a))
-	}
-	return
-}
-
 func (d Decoder) decodeSlice(to reflect.Value) (t Type, err error) {
 	return d.decodeSliceWith(to, decodeFuncOf(to.Type().Elem()))
 }
@@ -1016,11 +872,11 @@ func (d Decoder) decodePointerWith(to reflect.Value, f decodeFunc) (typ Type, er
 }
 
 func (d Decoder) decodeDecoderPointer(to reflect.Value) (Type, error) {
-	return Bool /* just needs to not be Nil */, to.Addr().Interface().(ValueDecoder).DecodeValue(d)
+	return Unknown /* just needs to not be Nil */, to.Addr().Interface().(ValueDecoder).DecodeValue(d)
 }
 
 func (d Decoder) decodeDecoder(to reflect.Value) (Type, error) {
-	return Bool /* just needs to not be Nil */, to.Interface().(ValueDecoder).DecodeValue(d)
+	return Unknown /* just needs to not be Nil */, to.Interface().(ValueDecoder).DecodeValue(d)
 }
 
 func (d Decoder) decodeTextUnmarshaler(to reflect.Value) (t Type, err error) {
@@ -1393,6 +1249,14 @@ func decodeFuncOf(t reflect.Type) decodeFunc {
 }
 
 func makeDecodeFunc(t reflect.Type, opts decodeFuncOpts) decodeFunc {
+	if a, ok := adapterOf(t); ok {
+		decode := a.Decode
+		return func(d Decoder, v reflect.Value) (Type, error) {
+			err := decode(d, v)
+			return Unknown /* just needs to not be Nil */, err
+		}
+	}
+
 	// fast path: check if it's a basic go type
 	switch t {
 	case boolType:
@@ -1421,27 +1285,6 @@ func makeDecodeFunc(t reflect.Type, opts decodeFuncOpts) decodeFunc {
 
 	case float32Type, float64Type:
 		return Decoder.decodeFloat
-
-	case netTCPAddrType:
-		return Decoder.decodeTCPAddr
-
-	case netUDPAddrType:
-		return Decoder.decodeUDPAddr
-
-	case netUnixAddrType:
-		return Decoder.decodeUnixAddr
-
-	case netIPAddrType:
-		return Decoder.decodeIPAddr
-
-	case netIPType:
-		return Decoder.decodeIP
-
-	case urlURLType:
-		return Decoder.decodeURL
-
-	case mailAddressType:
-		return Decoder.decodeEmail
 	}
 
 	// check if it implements one of the special case interfaces

--- a/decode.go
+++ b/decode.go
@@ -1249,7 +1249,7 @@ func decodeFuncOf(t reflect.Type) decodeFunc {
 }
 
 func makeDecodeFunc(t reflect.Type, opts decodeFuncOpts) decodeFunc {
-	if a, ok := adapterOf(t); ok {
+	if a, ok := AdapterOf(t); ok {
 		decode := a.Decode
 		return func(d Decoder, v reflect.Value) (Type, error) {
 			err := decode(d, v)

--- a/encode.go
+++ b/encode.go
@@ -4,9 +4,6 @@ import (
 	"encoding"
 	"fmt"
 	"io"
-	"net"
-	"net/mail"
-	"net/url"
 	"reflect"
 	"time"
 )
@@ -224,35 +221,6 @@ func (e Encoder) encodeDuration(v reflect.Value) error {
 
 func (e Encoder) encodeError(v reflect.Value) error {
 	return e.Emitter.EmitError(v.Interface().(error))
-}
-
-func (e Encoder) encodeTCPAddr(v reflect.Value) error {
-	a := v.Interface().(net.TCPAddr)
-	return e.Emitter.EmitString(a.String())
-}
-
-func (e Encoder) encodeUDPAddr(v reflect.Value) error {
-	a := v.Interface().(net.UDPAddr)
-	return e.Emitter.EmitString(a.String())
-}
-
-func (e Encoder) encodeIPAddr(v reflect.Value) error {
-	a := v.Interface().(net.IPAddr)
-	return e.Emitter.EmitString(a.String())
-}
-
-func (e Encoder) encodeIP(v reflect.Value) error {
-	return e.Emitter.EmitString(v.Interface().(net.IP).String())
-}
-
-func (e Encoder) encodeURL(v reflect.Value) error {
-	u := v.Interface().(url.URL)
-	return e.Emitter.EmitString(u.String())
-}
-
-func (e Encoder) encodeEmail(v reflect.Value) error {
-	a := v.Interface().(mail.Address)
-	return e.Emitter.EmitString(a.String())
 }
 
 func (e Encoder) encodeArray(v reflect.Value) error {
@@ -703,6 +671,10 @@ func encodeFuncOf(t reflect.Type) encodeFunc {
 }
 
 func makeEncodeFunc(t reflect.Type, opts encodeFuncOpts) encodeFunc {
+	if adapter, ok := adapterOf(t); ok {
+		return adapter.Encode
+	}
+
 	switch t {
 	case boolType:
 		return Encoder.encodeBool
@@ -760,24 +732,6 @@ func makeEncodeFunc(t reflect.Type, opts encodeFuncOpts) encodeFunc {
 
 	case float64Type:
 		return Encoder.encodeFloat64
-
-	case netTCPAddrType:
-		return Encoder.encodeTCPAddr
-
-	case netUDPAddrType:
-		return Encoder.encodeUDPAddr
-
-	case netIPAddrType:
-		return Encoder.encodeIPAddr
-
-	case netIPType:
-		return Encoder.encodeIP
-
-	case urlURLType:
-		return Encoder.encodeURL
-
-	case mailAddressType:
-		return Encoder.encodeEmail
 	}
 
 	switch {

--- a/encode.go
+++ b/encode.go
@@ -671,7 +671,7 @@ func encodeFuncOf(t reflect.Type) encodeFunc {
 }
 
 func makeEncodeFunc(t reflect.Type, opts encodeFuncOpts) encodeFunc {
-	if adapter, ok := adapterOf(t); ok {
+	if adapter, ok := AdapterOf(t); ok {
 		return adapter.Encode
 	}
 

--- a/encode_test.go
+++ b/encode_test.go
@@ -3,9 +3,6 @@ package objconv
 import (
 	"errors"
 	"fmt"
-	"net"
-	"net/mail"
-	"net/url"
 	"reflect"
 	"testing"
 	"time"
@@ -32,14 +29,6 @@ type TBytes []byte
 func TestEncoder(t *testing.T) {
 	now := time.Now()
 	err := errors.New("error")
-
-	ip := net.ParseIP("::1")
-	ipAddr := net.IPAddr{IP: ip, Zone: "zone"}
-	tcpAddr := net.TCPAddr{IP: ip, Port: 4242, Zone: "zone"}
-	udpAddr := net.UDPAddr{IP: ip, Port: 4242, Zone: "zone"}
-
-	location, _ := url.Parse("http://localhost:4242/hello/world?answer=42#question")
-	email, _ := mail.ParseAddress("git@github.com")
 
 	tests := [...]struct {
 		in  interface{}
@@ -102,18 +91,6 @@ func TestEncoder(t *testing.T) {
 
 		// error
 		{err, err},
-
-		// net
-		{ip, "::1"},
-		{ipAddr, "::1%zone"},
-		{tcpAddr, "[::1%zone]:4242"},
-		{udpAddr, "[::1%zone]:4242"},
-
-		// url
-		{location, "http://localhost:4242/hello/world?answer=42#question"},
-
-		// email
-		{email, "<git@github.com>"},
 
 		// array
 		{[...]int{1, 2, 3}, []interface{}{int64(1), int64(2), int64(3)}},

--- a/objtests/test_codec.go
+++ b/objtests/test_codec.go
@@ -152,6 +152,7 @@ var TestValues = [...]interface{}{
 
 	// mail
 	parseEmail("git@github.com"),
+	parseEmailList("Alice <alice@example.com>, Bob <bob@example.com>, Eve <eve@example.com>"),
 }
 
 func makeMap(n int) map[string]string {
@@ -382,4 +383,9 @@ func parseQuery(s string) url.Values {
 func parseEmail(s string) mail.Address {
 	a, _ := mail.ParseAddress(s)
 	return *a
+}
+
+func parseEmailList(s string) []*mail.Address {
+	l, _ := mail.ParseAddressList(s)
+	return l
 }

--- a/objtests/test_codec.go
+++ b/objtests/test_codec.go
@@ -148,6 +148,7 @@ var TestValues = [...]interface{}{
 
 	// url
 	parseURL("http://localhost:4242/hello/world?answer=42#question"),
+	parseQuery("answer=42&message=Hello+World"),
 
 	// mail
 	parseEmail("git@github.com"),
@@ -371,6 +372,11 @@ func benchmarkStreamDecoder(b *testing.B, codec objconv.Codec) {
 func parseURL(s string) url.URL {
 	u, _ := url.Parse(s)
 	return *u
+}
+
+func parseQuery(s string) url.Values {
+	v, _ := url.ParseQuery(s)
+	return v
 }
 
 func parseEmail(s string) mail.Address {

--- a/objtests/test_codec.go
+++ b/objtests/test_codec.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/segmentio/objconv"
+	_ "github.com/segmentio/objconv/adapters"
 )
 
 // TestValues is an array of all the values used by the TestCodec suite.

--- a/parse.go
+++ b/parse.go
@@ -3,10 +3,7 @@ package objconv
 import (
 	"errors"
 	"fmt"
-	"net"
 	"reflect"
-	"strconv"
-	"strings"
 	"time"
 )
 
@@ -508,34 +505,6 @@ func ParseUintHex(b []byte) (uint64, error) {
 	}
 
 	return val, nil
-}
-
-func parseNetAddr(s string) (ip net.IP, port int, zone string, err error) {
-	var h string
-	var p string
-
-	if h, p, err = net.SplitHostPort(s); err != nil {
-		h, p = s, ""
-	}
-
-	if len(h) != 0 {
-		if off := strings.IndexByte(h, '%'); off >= 0 {
-			h, zone = h[:off], h[off+1:]
-		}
-		if ip = net.ParseIP(h); ip == nil {
-			err = errors.New("objconv: bad IP address: " + s)
-			return
-		}
-	}
-
-	if len(p) != 0 {
-		if port, err = strconv.Atoi(p); err != nil || port < 0 || port > 65535 {
-			err = errors.New("objconv: bad port number: " + s)
-			return
-		}
-	}
-
-	return
 }
 
 func errorInvalidInt64(b []byte) error {

--- a/struct.go
+++ b/struct.go
@@ -130,6 +130,15 @@ func (cache *structTypeCache) lookup(t reflect.Type) (s *structType) {
 	return
 }
 
+// clear empties the cache.
+func (cache *structTypeCache) clear() {
+	cache.mutex.Lock()
+	for typ := range cache.store {
+		delete(cache.store, typ)
+	}
+	cache.mutex.Unlock()
+}
+
 var (
 	// This struct cache is used to avoid reusing reflection over and over when
 	// the objconv functions are called. The performance improvements on iterating

--- a/value.go
+++ b/value.go
@@ -2,9 +2,6 @@ package objconv
 
 import (
 	"encoding"
-	"net"
-	"net/mail"
-	"net/url"
 	"reflect"
 	"sync"
 	"time"
@@ -192,13 +189,6 @@ var (
 	durationType       = reflect.TypeOf(time.Duration(0))
 	sliceInterfaceType = reflect.TypeOf(([]interface{})(nil))
 	timePtrType        = reflect.PtrTo(timeType)
-	netTCPAddrType     = reflect.TypeOf(net.TCPAddr{})
-	netUDPAddrType     = reflect.TypeOf(net.UDPAddr{})
-	netUnixAddrType    = reflect.TypeOf(net.UnixAddr{})
-	netIPAddrType      = reflect.TypeOf(net.IPAddr{})
-	netIPType          = reflect.TypeOf(net.IP(nil))
-	urlURLType         = reflect.TypeOf(url.URL{})
-	mailAddressType    = reflect.TypeOf(mail.Address{})
 
 	// interfaces
 	errorInterface           = elemTypeOf((*error)(nil))


### PR DESCRIPTION
@f2prateek 
@yields 

Following Prateek's advice in #6, this PR adds an adapter API which makes it possible to extend the types supported by the objconv encoders and decoders in situations where the types themselves cannot be modified to implement `objconv.ValueEncoder` and `objconv.ValueDecoder`.

Please take a look and le me know if you'd like to see anything changed.