### PR TITLE
increase compatibility with encoding/json by supporting json struct tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,6 @@ that mirror those of the standard library to make it easy to integrate with the
 objconv package. However there are a couple of differences that need to be taken
 in consideration:
 
-- When struct tags are used to define the behavior of marshaling or unmarshaling
-structs, the tag name needs to be `objconv` (instead of `json` for example).
-
 - Encoder and Decoder types are not exposed in the objconv sub-packages, instead
 the types from the top-level package are used. For example, variables declared
 with the `json.Encoder` type would have to be replaced with `objconv.Encoder`.

--- a/emit.go
+++ b/emit.go
@@ -69,6 +69,14 @@ type PrettyEmitter interface {
 	PrettyEmitter() Emitter
 }
 
+// The marshaler interface may be implemented by emitters that may provide a
+// special marshaling implementation for certain types.
+//
+// A good example of this is the json emitter which uses
+type marshaler interface {
+	Marshal(interface{}) (bool, error)
+}
+
 type discardEmitter struct{}
 
 func (e discardEmitter) EmitNil() error                     { return nil }

--- a/emit.go
+++ b/emit.go
@@ -69,14 +69,6 @@ type PrettyEmitter interface {
 	PrettyEmitter() Emitter
 }
 
-// The marshaler interface may be implemented by emitters that may provide a
-// special marshaling implementation for certain types.
-//
-// A good example of this is the json emitter which uses
-type marshaler interface {
-	Marshal(interface{}) (bool, error)
-}
-
 type discardEmitter struct{}
 
 func (e discardEmitter) EmitNil() error                     { return nil }

--- a/encode_test.go
+++ b/encode_test.go
@@ -122,6 +122,19 @@ func TestEncoder(t *testing.T) {
 			},
 		},
 
+		// struct tags (json)
+		{
+			in: &struct {
+				A bool `json:"a"`
+				B bool `json:"b,omitempty"`
+				C bool `json:"c,omitzero"`
+			}{true, false, false},
+			out: map[interface{}]interface{}{
+				"a": true,
+				"c": false,
+			},
+		},
+
 		// list of complex data structures
 		{
 			in: []map[string]string{

--- a/json/bench_test.go
+++ b/json/bench_test.go
@@ -22,18 +22,18 @@ import (
 )
 
 type codeResponse struct {
-	Tree     *codeNode `objconv:"tree"`
-	Username string    `objconv:"username"`
+	Tree     *codeNode `json:"tree"`
+	Username string    `json:"username"`
 }
 
 type codeNode struct {
-	Name     string      `objconv:"name"`
-	Kids     []*codeNode `objconv:"kids"`
-	CLWeight float64     `objconv:"cl_weight"`
-	Touches  int         `objconv:"touches"`
-	MinT     int64       `objconv:"min_t"`
-	MaxT     int64       `objconv:"max_t"`
-	MeanT    int64       `objconv:"mean_t"`
+	Name     string      `json:"name"`
+	Kids     []*codeNode `json:"kids"`
+	CLWeight float64     `json:"cl_weight"`
+	Touches  int         `json:"touches"`
+	MinT     int64       `json:"min_t"`
+	MaxT     int64       `json:"max_t"`
+	MeanT    int64       `json:"mean_t"`
 }
 
 var codeOnce sync.Once

--- a/objutil/tag.go
+++ b/objutil/tag.go
@@ -40,6 +40,28 @@ func ParseTag(s string) Tag {
 	}
 }
 
+// ParseTagJSON is similar to ParseTag but only supports features supported by
+// the standard encoding/json package.
+func ParseTagJSON(s string) Tag {
+	var name string
+	var omitempty bool
+
+	name, s = parseNextTagToken(s)
+
+	for len(s) != 0 {
+		var token string
+		switch token, s = parseNextTagToken(s); token {
+		case "omitempty":
+			omitempty = true
+		}
+	}
+
+	return Tag{
+		Name:      name,
+		Omitempty: omitempty,
+	}
+}
+
 func parseNextTagToken(s string) (token string, next string) {
 	if split := strings.IndexByte(s, ','); split < 0 {
 		token = s

--- a/objutil/tag_test.go
+++ b/objutil/tag_test.go
@@ -31,6 +31,54 @@ func TestParseTag(t *testing.T) {
 			tag: "-,omitempty",
 			res: Tag{Name: "-", Omitempty: true},
 		},
+		{
+			tag: "hello,omitzero",
+			res: Tag{Name: "hello", Omitzero: true},
+		},
+		{
+			tag: "-,omitempty,omitzero",
+			res: Tag{Name: "-", Omitempty: true, Omitzero: true},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.tag, func(t *testing.T) {
+			if res := ParseTag(test.tag); res != test.res {
+				t.Errorf("%s: %#v != %#v", test.tag, test.res, res)
+			}
+		})
+	}
+}
+
+func TestParseTagJSON(t *testing.T) {
+	tests := []struct {
+		tag string
+		res Tag
+	}{
+		{
+			tag: "",
+			res: Tag{},
+		},
+		{
+			tag: "hello",
+			res: Tag{Name: "hello"},
+		},
+		{
+			tag: ",omitempty",
+			res: Tag{Omitempty: true},
+		},
+		{
+			tag: "-",
+			res: Tag{Name: "-"},
+		},
+		{
+			tag: "hello,omitempty",
+			res: Tag{Name: "hello", Omitempty: true},
+		},
+		{
+			tag: "-,omitempty",
+			res: Tag{Name: "-", Omitempty: true},
+		},
 	}
 
 	for _, test := range tests {

--- a/struct.go
+++ b/struct.go
@@ -30,7 +30,21 @@ type structField struct {
 }
 
 func makeStructField(f reflect.StructField, c map[reflect.Type]*structType) structField {
-	t := objutil.ParseTag(f.Tag.Get("objconv"))
+	var t objutil.Tag
+
+	if tag := f.Tag.Get("objconv"); len(tag) != 0 {
+		t = objutil.ParseTag(tag)
+	} else {
+		// To maximize compatibility with existing code we fallback to checking
+		// if the field has a `json` tag.
+		//
+		// This tag doesn't support any of the extra features that are supported
+		// by the `objconv` tag, and it should stay this way. It has to match
+		// the behavior of the standard encoding/json package to avoid any
+		// implicit changes in what would be intuitively expected.
+		t = objutil.ParseTagJSON(f.Tag.Get("json"))
+	}
+
 	s := structField{
 		index:     f.Index,
 		name:      f.Name,

--- a/yaml/vendor/gopkg.in/yaml.v2/decode_test.go
+++ b/yaml/vendor/gopkg.in/yaml.v2/decode_test.go
@@ -2,13 +2,14 @@ package yaml_test
 
 import (
 	"errors"
-	. "gopkg.in/check.v1"
-	"gopkg.in/yaml.v2"
 	"math"
 	"net"
 	"reflect"
 	"strings"
 	"time"
+
+	. "gopkg.in/check.v1"
+	"gopkg.in/yaml.v2"
 )
 
 var unmarshalIntTest = 123
@@ -551,7 +552,7 @@ var unmarshalTests = []struct {
 	},
 	{
 		"a: 2015-02-24T18:19:39Z\n",
-		map[string]time.Time{"a": time.Unix(1424801979, 0)},
+		map[string]time.Time{"a": time.Unix(1424801979, 0).UTC()},
 	},
 
 	// Encode empty lists as zero-length slices.


### PR DESCRIPTION
Per Ilya's request, in order to make transitions of existing code bases to objconv easier, make a special case for the `json` struct field tag.