### PR TITLE
Support encoding.BinaryMarshaler and encoding.BinaryUnmarshaler

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -1327,8 +1327,6 @@ func makeDecodeFunc(t reflect.Type, opts decodeFuncOpts) decodeFunc {
 	}
 
 	// check if it implements one of the special case interfaces
-	binaryUnmarshaler := t.Implements(binaryUnmarshalerInterface)
-	textUnmarshaler := t.Implements(textUnmarshalerInterface)
 	switch p := reflect.PtrTo(t); {
 	case t.Implements(valueDecoderInterface):
 		return Decoder.decodeDecoder
@@ -1339,13 +1337,13 @@ func makeDecodeFunc(t reflect.Type, opts decodeFuncOpts) decodeFunc {
 	case t.Implements(errorInterface):
 		return Decoder.decodeError
 
-	case binaryUnmarshaler && textUnmarshaler:
+	case t.Implements(binaryUnmarshalerInterface) && t.Implements(textUnmarshalerInterface):
 		return Decoder.decodeUnmarshaler
 
-	case binaryUnmarshaler:
+	case t.Implements(binaryUnmarshalerInterface):
 		return Decoder.decodeBinaryUnmarshaler
 
-	case textUnmarshaler:
+	case t.Implements(textUnmarshalerInterface):
 		return Decoder.decodeTextUnmarshaler
 	}
 

--- a/emit.go
+++ b/emit.go
@@ -69,17 +69,16 @@ type PrettyEmitter interface {
 	PrettyEmitter() Emitter
 }
 
-// The TextEmitter interface may be implemented by emitters of human-readable
+// The textEmitter interface may be implemented by emitters of human-readable
 // formats. Such emitters instruct the encoder to prefer using
 // encoding.TextMarshaler over encoding.BinaryMarshaler for example.
-type TextEmitter interface {
+type textEmitter interface {
 	// EmitsText returns true if the emitter produces a human-readable format.
 	TextEmitter() bool
 }
 
-// IsTextEmitter returns true if the emitter produces a human-readable format.
-func IsTextEmitter(emitter Emitter) bool {
-	e, _ := emitter.(TextEmitter)
+func isTextEmitter(emitter Emitter) bool {
+	e, _ := emitter.(textEmitter)
 	return e != nil && e.TextEmitter()
 }
 

--- a/emit.go
+++ b/emit.go
@@ -69,6 +69,20 @@ type PrettyEmitter interface {
 	PrettyEmitter() Emitter
 }
 
+// The TextEmitter interface may be implemented by emitters of human-readable
+// formats. Such emitters instruct the encoder to prefer using
+// encoding.TextMarshaler over encoding.BinaryMarshaler for example.
+type TextEmitter interface {
+	// EmitsText returns true if the emitter produces a human-readable format.
+	TextEmitter() bool
+}
+
+// IsTextEmitter returns true if the emitter produces a human-readable format.
+func IsTextEmitter(emitter Emitter) bool {
+	e, _ := emitter.(TextEmitter)
+	return e != nil && e.TextEmitter()
+}
+
 type discardEmitter struct{}
 
 func (e discardEmitter) EmitNil() error                     { return nil }

--- a/encode.go
+++ b/encode.go
@@ -442,14 +442,14 @@ func (e Encoder) encodeEncoder(v reflect.Value) error {
 }
 
 func (e Encoder) encodeMarshaler(v reflect.Value) error {
-	if IsTextEmitter(e.Emitter) {
+	if isTextEmitter(e.Emitter) {
 		return e.encodeTextMarshaler(v)
 	}
 	return e.encodeBinaryMarshaler(v)
 }
 
 func (e Encoder) encodeBinaryMarshaler(v reflect.Value) error {
-	b, err := v.Interface().(encoding.TextMarshaler).MarshalText()
+	b, err := v.Interface().(encoding.BinaryMarshaler).MarshalBinary()
 	if err == nil {
 		err = e.Emitter.EmitBytes(b)
 	}

--- a/encode.go
+++ b/encode.go
@@ -749,19 +749,17 @@ func makeEncodeFunc(t reflect.Type, opts encodeFuncOpts) encodeFunc {
 		return Encoder.encodeFloat64
 	}
 
-	binaryMarshaler := t.Implements(binaryMarshalerInterface)
-	textMarshaler := t.Implements(textMarshalerInterface)
 	switch {
 	case t.Implements(valueEncoderInterface):
 		return Encoder.encodeEncoder
 
-	case binaryMarshaler && textMarshaler:
+	case t.Implements(binaryMarshalerInterface) && t.Implements(textMarshalerInterface):
 		return Encoder.encodeMarshaler
 
-	case binaryMarshaler:
+	case t.Implements(binaryMarshalerInterface):
 		return Encoder.encodeBinaryMarshaler
 
-	case textMarshaler:
+	case t.Implements(textMarshalerInterface):
 		return Encoder.encodeTextMarshaler
 
 	case t.Implements(errorInterface):

--- a/json/emit.go
+++ b/json/emit.go
@@ -202,6 +202,10 @@ func (e *Emitter) EmitMapNext() (err error) {
 	return
 }
 
+func (e *Emitter) TextEmitter() bool {
+	return true
+}
+
 func (e *Emitter) PrettyEmitter() objconv.Emitter {
 	return NewPrettyEmitter(e.w)
 }
@@ -292,6 +296,10 @@ func (e *PrettyEmitter) EmitMapNext() (err error) {
 		return
 	}
 	return e.indent()
+}
+
+func (e *PrettyEmitter) TextEmitter() bool {
+	return true
 }
 
 func (e *PrettyEmitter) indent() (err error) {

--- a/json/parse.go
+++ b/json/parse.go
@@ -325,6 +325,10 @@ func (p *Parser) ParseMapNext(n int) (err error) {
 	return
 }
 
+func (p *Parser) TextParser() bool {
+	return true
+}
+
 func (p *Parser) DecodeBytes(b []byte) (v []byte, err error) {
 	var n int
 	if n, err = base64.StdEncoding.Decode(b, b); err != nil {

--- a/objtests/test_codec.go
+++ b/objtests/test_codec.go
@@ -396,6 +396,9 @@ func parseEmailList(s string) []*mail.Address {
 	return l
 }
 
+// This type implements the encoding.BinaryMarshaler, encoding.TextMarshaler,
+// encoding.BinaryUnmarshaler, and encoding.TextUnmarshaler. It's used to verify
+// the support for those interfaces is working as expected for all codecs.
 type point struct {
 	x int32
 	y int32

--- a/parse.go
+++ b/parse.go
@@ -123,3 +123,16 @@ type bytesDecoder interface {
 	// before the value is stored.
 	DecodeBytes([]byte) ([]byte, error)
 }
+
+// The textParser interface may be implemented by parsers of human-readable
+// formats. Such parsers instruct the encoder to prefer using
+// encoding.TextUnmarshaler over encoding.BinaryUnmarshaler for example.
+type textParser interface {
+	// EmitsText returns true if the parser produces a human-readable format.
+	TextParser() bool
+}
+
+func isTextParser(parser Parser) bool {
+	p, _ := parser.(textParser)
+	return p != nil && p.TextParser()
+}

--- a/value.go
+++ b/value.go
@@ -107,12 +107,14 @@ var (
 	timePtrType        = reflect.PtrTo(timeType)
 
 	// interfaces
-	errorInterface           = elemTypeOf((*error)(nil))
-	valueEncoderInterface    = elemTypeOf((*ValueEncoder)(nil))
-	valueDecoderInterface    = elemTypeOf((*ValueDecoder)(nil))
-	textMarshalerInterface   = elemTypeOf((*encoding.TextMarshaler)(nil))
-	textUnmarshalerInterface = elemTypeOf((*encoding.TextUnmarshaler)(nil))
-	emptyInterface           = elemTypeOf((*interface{})(nil))
+	errorInterface             = elemTypeOf((*error)(nil))
+	valueEncoderInterface      = elemTypeOf((*ValueEncoder)(nil))
+	valueDecoderInterface      = elemTypeOf((*ValueDecoder)(nil))
+	binaryMarshalerInterface   = elemTypeOf((*encoding.BinaryMarshaler)(nil))
+	binaryUnmarshalerInterface = elemTypeOf((*encoding.BinaryUnmarshaler)(nil))
+	textMarshalerInterface     = elemTypeOf((*encoding.TextMarshaler)(nil))
+	textUnmarshalerInterface   = elemTypeOf((*encoding.TextUnmarshaler)(nil))
+	emptyInterface             = elemTypeOf((*interface{})(nil))
 
 	// common map types, used for optimization for map encoding algorithms
 	mapStringStringType       = reflect.TypeOf((map[string]string)(nil))

--- a/yaml/emit.go
+++ b/yaml/emit.go
@@ -98,6 +98,10 @@ func (e *Emitter) EmitMapNext() (err error) {
 	return
 }
 
+func (e *Emitter) TextEmitter() bool {
+	return true
+}
+
 func (e *Emitter) emit(v interface{}) (err error) {
 	var b []byte
 

--- a/yaml/parse.go
+++ b/yaml/parse.go
@@ -182,6 +182,10 @@ func (p *Parser) ParseMapNext(n int) (err error) {
 	return
 }
 
+func (p *Parser) TextParser() bool {
+	return true
+}
+
 func (p *Parser) DecodeBytes(b []byte) (v []byte, err error) {
 	var n int
 	if n, err = base64.StdEncoding.Decode(b, b); err != nil {


### PR DESCRIPTION
Hey guys, in view of making a bit of noise around this open source package I want to make it as backward compatible as possible with the standard library's encoding/json. This PR adds support for types that implement the `encoding.BinaryMarshaler` and `encoding.BinaryUnmarshaler`.

Since this is intended to be here for compatibility purposes, no work has been done to make the implementation memory or compute efficient, there's anyway a memory allocation that is forced by the design of those interfaces and that cannot be taken away.
I did check that it's not impacting global performances of the encoders/decoders.

Please take a look and let me know what you think about this.