### PR TITLE
optimize CBOR string emitter

### DIFF
--- a/cbor/emit.go
+++ b/cbor/emit.go
@@ -3,7 +3,9 @@ package cbor
 import (
 	"io"
 	"math"
+	"reflect"
 	"time"
+	"unsafe"
 
 	"github.com/segmentio/objconv/objutil"
 )
@@ -12,7 +14,7 @@ import (
 // interface.
 type Emitter struct {
 	w io.Writer
-	b [240]byte
+	b [10]byte
 
 	// This stack is used to keep track of the array map lengths being parsed.
 	// The sback array is the initial backend array for the stack.
@@ -79,24 +81,13 @@ func (e *Emitter) EmitString(v string) (err error) {
 	if err = e.emitUint(majorType3, uint64(len(v))); err != nil {
 		return
 	}
-
-	for len(v) != 0 {
-		n1 := len(v)
-		n2 := len(e.b)
-
-		if n1 > n2 {
-			n1 = n2
-		}
-
-		copy(e.b[:], v[:n1])
-
-		if _, err = e.w.Write(e.b[:n1]); err != nil {
-			return
-		}
-
-		v = v[n1:]
+	s := *(*reflect.StringHeader)(unsafe.Pointer(&v))
+	b := reflect.SliceHeader{
+		Data: s.Data,
+		Len:  s.Len,
+		Cap:  s.Len,
 	}
-
+	_, err = e.w.Write(*((*[]byte)(unsafe.Pointer(&b))))
 	return
 }
 

--- a/cbor/emit.go
+++ b/cbor/emit.go
@@ -14,7 +14,7 @@ import (
 // interface.
 type Emitter struct {
 	w io.Writer
-	b [10]byte
+	b [16]byte
 
 	// This stack is used to keep track of the array map lengths being parsed.
 	// The sback array is the initial backend array for the stack.


### PR DESCRIPTION
This hack prevents the string from having to be copied to be written to the io.Writer, which leads to huge performance gains for longer strings.

The code take a small performance hit on empty strings because the writer's `Write` method used to not be called in this case (and now it is), I've tested adding a `if len(v) != 0` but it slows down all the other cases, I think the tradeoff is fine.
```
benchmark                                                                           old ns/op     new ns/op     delta
BenchmarkCodec/Encoder/string:-4                                                    83.1          90.3          +8.66%
BenchmarkCodec/Encoder/string:Hello_World!-4                                        98.5          89.6          -9.04%
BenchmarkCodec/Encoder/string:Hello"World!-4                                        93.9          89.1          -5.11%
BenchmarkCodec/Encoder/string:Hello\World!-4                                        93.7          89.5          -4.48%
BenchmarkCodec/Encoder/string:Hello_World!#01-4                                     93.0          90.7          -2.47%
BenchmarkCodec/Encoder/string:Hello_World!#02-4                                     94.2          90.5          -3.93%
BenchmarkCodec/Encoder/string:Hello_World!#03-4                                     93.6          92.4          -1.28%
BenchmarkCodec/Encoder/string:Hello\bWorld!-4                                       94.9          90.5          -4.64%
BenchmarkCodec/Encoder/string:Hello_World!#04-4                                     94.0          90.0          -4.26%
BenchmarkCodec/Encoder/string:你好-4                                                  92.9          89.0          -4.20%
BenchmarkCodec/Encoder/string:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-4                    95.3          90.0          -5.56%
BenchmarkCodec/Encoder/string:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA...-4              108           90.8          -15.93%
BenchmarkCodec/Encoder/string:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA...#01-4           4203          94.1          -97.76%
BenchmarkCodec/StreamEncoder/string:-4                                              95.4          99.6          +4.40%
BenchmarkCodec/StreamEncoder/string:Hello_World!-4                                  103           108           +4.85%
BenchmarkCodec/StreamEncoder/string:Hello"World!-4                                  102           103           +0.98%
BenchmarkCodec/StreamEncoder/string:Hello\World!-4                                  101           97.4          -3.56%
BenchmarkCodec/StreamEncoder/string:Hello_World!#01-4                               102           99.0          -2.94%
BenchmarkCodec/StreamEncoder/string:Hello_World!#02-4                               105           98.2          -6.48%
BenchmarkCodec/StreamEncoder/string:Hello_World!#03-4                               103           98.4          -4.47%
BenchmarkCodec/StreamEncoder/string:Hello\bWorld!-4                                 101           98.7          -2.28%
BenchmarkCodec/StreamEncoder/string:Hello_World!#04-4                               103           97.4          -5.44%
BenchmarkCodec/StreamEncoder/string:你好-4                                            100           98.8          -1.20%
BenchmarkCodec/StreamEncoder/string:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-4              102           99.6          -2.35%
BenchmarkCodec/StreamEncoder/string:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA...-4        115           98.8          -14.09%
BenchmarkCodec/StreamEncoder/string:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA...#01-4     4245          98.6          -97.68%

benchmark                                                                           old MB/s     new MB/s      speedup
BenchmarkCodec/Encoder/string:-4                                                    12.03        11.08         0.92x
BenchmarkCodec/Encoder/string:Hello_World!-4                                        132.02       145.02        1.10x
BenchmarkCodec/Encoder/string:Hello"World!-4                                        138.51       145.83        1.05x
BenchmarkCodec/Encoder/string:Hello\World!-4                                        138.81       145.31        1.05x
BenchmarkCodec/Encoder/string:Hello_World!#01-4                                     139.72       143.40        1.03x
BenchmarkCodec/Encoder/string:Hello_World!#02-4                                     137.96       143.68        1.04x
BenchmarkCodec/Encoder/string:Hello_World!#03-4                                     138.92       140.75        1.01x
BenchmarkCodec/Encoder/string:Hello\bWorld!-4                                       136.92       143.58        1.05x
BenchmarkCodec/Encoder/string:Hello_World!#04-4                                     138.25       144.40        1.04x
BenchmarkCodec/Encoder/string:你好-4                                                  75.33        78.68         1.04x
BenchmarkCodec/Encoder/string:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-4                    356.87       377.87        1.06x
BenchmarkCodec/Encoder/string:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA...-4              2396.84      2852.94       1.19x
BenchmarkCodec/Encoder/string:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA...#01-4           15592.43     696632.80     44.68x
BenchmarkCodec/StreamEncoder/string:-4                                              10.49        10.05         0.96x
BenchmarkCodec/StreamEncoder/string:Hello_World!-4                                  125.21       120.27        0.96x
BenchmarkCodec/StreamEncoder/string:Hello"World!-4                                  126.52       126.17        1.00x
BenchmarkCodec/StreamEncoder/string:Hello\World!-4                                  127.93       133.51        1.04x
BenchmarkCodec/StreamEncoder/string:Hello_World!#01-4                               126.55       131.34        1.04x
BenchmarkCodec/StreamEncoder/string:Hello_World!#02-4                               123.51       132.44        1.07x
BenchmarkCodec/StreamEncoder/string:Hello_World!#03-4                               125.47       132.10        1.05x
BenchmarkCodec/StreamEncoder/string:Hello\bWorld!-4                                 128.41       131.75        1.03x
BenchmarkCodec/StreamEncoder/string:Hello_World!#04-4                               125.89       133.47        1.06x
BenchmarkCodec/StreamEncoder/string:你好-4                                            69.93        70.87         1.01x
BenchmarkCodec/StreamEncoder/string:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA-4              332.58       341.53        1.03x
BenchmarkCodec/StreamEncoder/string:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA...-4        2240.56      2622.69       1.17x
BenchmarkCodec/StreamEncoder/string:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA...#01-4     15437.14     664750.47     43.06x
```
