### PR TITLE
Fix key overwrite when kv separate requires fill

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -840,13 +840,12 @@ func (d Decoder) decodeStructFromTypeWith(typ Type, to reflect.Value, s *structT
 		if _, b, err = d.decodeTypeAndString(); err != nil {
 			return
 		}
-		k := string(b)
+		f := s.fieldsByName[string(b)]
 
 		if err = d.Parser.ParseMapValue(vd.off - 1); err != nil {
 			return
 		}
 
-		f := s.fieldsByName[k]
 		if f == nil {
 			_, err = d.decodeInterface(reflect.Value{}) // discard
 			return

--- a/decode.go
+++ b/decode.go
@@ -840,12 +840,13 @@ func (d Decoder) decodeStructFromTypeWith(typ Type, to reflect.Value, s *structT
 		if _, b, err = d.decodeTypeAndString(); err != nil {
 			return
 		}
+		k := string(b)
 
 		if err = d.Parser.ParseMapValue(vd.off - 1); err != nil {
 			return
 		}
 
-		f := s.fieldsByName[string(b)]
+		f := s.fieldsByName[k]
 		if f == nil {
 			_, err = d.decodeInterface(reflect.Value{}) // discard
 			return

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -1,6 +1,8 @@
 package json
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/segmentio/objconv/objtests"
@@ -43,5 +45,24 @@ func TestUnicode(t *testing.T) {
 				t.Error(s)
 			}
 		})
+	}
+}
+
+func TestMapValueOverflow(t *testing.T) {
+	src := fmt.Sprintf(
+		`{"A":"good","skip1":"%s","B":"bad","skip2":"%sA"}`,
+		strings.Repeat("0", 102),
+		strings.Repeat("0", 110),
+	)
+
+	val := struct{ A string }{}
+
+	if err := Unmarshal([]byte(src), &val); err != nil {
+		t.Error(err)
+		return
+	}
+
+	if val.A != "good" {
+		t.Error(val.A)
 	}
 }


### PR DESCRIPTION
@achille-roussel @thehydroimpulse 

The key buffer points at the underlying read buffer. When reading the separator requires re-filling the buffer, the key would get clobbered with whatever data got filled.

In most cases, this likely results in dropping all data under this key. We hit the rare case where we ended up overwriting the key `error` with the key `event`, which caused the value of `error` to replace the value we already parsed out for `event`.

The test case aligns the key `B` so the 128 byte buffer ends with `"B"`, then when it re-fills to read the `:`, the buffer ends with `A"`, causing the value of `A` to be overwritten