### PR TITLE
optimize encoder for common types

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,12 @@ The top-level package exposes the generic types and algorithms for encoding and
 decoding values, while each sub-package implements the parser and emitters for
 specific types.
 
+### Breaking changes introduced in [#18](https://github.com/segmentio/objconv/pull/18)
+
+The `Encoder` type used to have methods exposed to encode specific types for
+optimization purposes. The generic `Encode` method has been optimized to make
+those other methods obsolete and they were therefore removed.
+
 Compatibility with the standard library
 ---------------------------------------
 

--- a/adapters/net/encode.go
+++ b/adapters/net/encode.go
@@ -9,25 +9,25 @@ import (
 
 func encodeTCPAddr(e objconv.Encoder, v reflect.Value) error {
 	a := v.Interface().(net.TCPAddr)
-	return e.Emitter.EmitString(a.String())
+	return e.Encode(a.String())
 }
 
 func encodeUDPAddr(e objconv.Encoder, v reflect.Value) error {
 	a := v.Interface().(net.UDPAddr)
-	return e.Emitter.EmitString(a.String())
+	return e.Encode(a.String())
 }
 
 func encodeUnixAddr(e objconv.Encoder, v reflect.Value) error {
 	a := v.Interface().(net.UnixAddr)
-	return e.Emitter.EmitString(a.String())
+	return e.Encode(a.String())
 }
 
 func encodeIPAddr(e objconv.Encoder, v reflect.Value) error {
 	a := v.Interface().(net.IPAddr)
-	return e.Emitter.EmitString(a.String())
+	return e.Encode(a.String())
 }
 
 func encodeIP(e objconv.Encoder, v reflect.Value) error {
 	a := v.Interface().(net.IP)
-	return e.Emitter.EmitString(a.String())
+	return e.Encode(a.String())
 }

--- a/adapters/net/mail/encode.go
+++ b/adapters/net/mail/encode.go
@@ -10,7 +10,7 @@ import (
 
 func encodeAddress(e objconv.Encoder, v reflect.Value) error {
 	a := v.Interface().(mail.Address)
-	return e.Emitter.EmitString(a.String())
+	return e.Encode(a.String())
 }
 
 func encodeAddressList(e objconv.Encoder, v reflect.Value) error {
@@ -27,5 +27,5 @@ func encodeAddressList(e objconv.Encoder, v reflect.Value) error {
 		b.WriteString(a.String())
 	}
 
-	return e.EncodeString(b.String())
+	return e.Encode(b.String())
 }

--- a/adapters/net/url/encode.go
+++ b/adapters/net/url/encode.go
@@ -9,10 +9,10 @@ import (
 
 func encodeURL(e objconv.Encoder, v reflect.Value) error {
 	u := v.Interface().(url.URL)
-	return e.Emitter.EmitString(u.String())
+	return e.Encode(u.String())
 }
 
 func encodeQuery(e objconv.Encoder, v reflect.Value) error {
 	q := v.Interface().(url.Values)
-	return e.Emitter.EmitString(q.Encode())
+	return e.Encode(q.Encode())
 }

--- a/encode.go
+++ b/encode.go
@@ -89,9 +89,6 @@ func (e Encoder) Encode(v interface{}) (err error) {
 	case time.Duration:
 		return e.Emitter.EmitDuration(x)
 
-	case error:
-		return e.Emitter.EmitError(x)
-
 	case []string:
 		return e.encodeSliceOfString(x)
 
@@ -151,9 +148,6 @@ func (e Encoder) Encode(v interface{}) (err error) {
 
 	case *time.Duration:
 		return e.Emitter.EmitDuration(*x)
-
-	case *error:
-		return e.Emitter.EmitError(*x)
 
 	case *[]string:
 		return e.encodeSliceOfString(*x)

--- a/encode.go
+++ b/encode.go
@@ -51,7 +51,7 @@ func (e Encoder) Encode(v interface{}) (err error) {
 		return e.Emitter.EmitBool(x)
 
 	case int:
-		return e.Emitter.EmitInt(int64(x), int(8*unsafe.Sizeof(0)))
+		return e.Emitter.EmitInt(int64(x), 0)
 
 	case int8:
 		return e.Emitter.EmitInt(int64(x), 8)

--- a/objtests/test_codec.go
+++ b/objtests/test_codec.go
@@ -114,6 +114,8 @@ var TestValues = [...]interface{}{
 	[]int{0, 1, 2, 3, 4, 5, 6, 7, 8, 9},
 	make([]int, objutil.Uint8Max+1),
 	make([]int, objutil.Uint16Max+1),
+	[]string{"A", "B", "C"},
+	[]interface{}{nil, true, false, 0.5, "Hello World!"},
 
 	// map
 	makeMap(0),


### PR DESCRIPTION
This leads a small throughput increase on the encoder benchmark and enables a memory optimization on the application side:
```
benchmark                  old ns/op     new ns/op     delta
BenchmarkCodeEncoder-4     12958944      12751068      -1.60%

benchmark                  old MB/s     new MB/s     speedup
BenchmarkCodeEncoder-4     149.74       152.18       1.02x

benchmark                  old allocs     new allocs     delta
BenchmarkCodeEncoder-4     0              0              +0.00%

benchmark                  old bytes     new bytes     delta
BenchmarkCodeEncoder-4     0             0             +0.00%
```