### PR TITLE
the JSON encoder should error when emitting NaN or Inf

### DIFF
--- a/json/emit.go
+++ b/json/emit.go
@@ -2,7 +2,9 @@ package json
 
 import (
 	"encoding/base64"
+	"errors"
 	"io"
+	"math"
 	"strconv"
 	"time"
 
@@ -71,7 +73,19 @@ func (e *Emitter) EmitUint(v uint64, _ int) (err error) {
 }
 
 func (e *Emitter) EmitFloat(v float64, bitSize int) (err error) {
-	_, err = e.w.Write(strconv.AppendFloat(e.s[:0], v, 'g', -1, bitSize))
+	switch {
+	case math.IsNaN(v):
+		err = errors.New("NaN has no json representation")
+
+	case math.IsInf(v, +1):
+		err = errors.New("+Inf has no json representation")
+
+	case math.IsInf(v, -1):
+		err = errors.New("-Inf has no json representation")
+
+	default:
+		_, err = e.w.Write(strconv.AppendFloat(e.s[:0], v, 'g', -1, bitSize))
+	}
 	return
 }
 

--- a/json/json_test.go
+++ b/json/json_test.go
@@ -2,6 +2,7 @@ package json
 
 import (
 	"fmt"
+	"math"
 	"strings"
 	"testing"
 
@@ -64,5 +65,23 @@ func TestMapValueOverflow(t *testing.T) {
 
 	if val.A != "good" {
 		t.Error(val.A)
+	}
+}
+
+func TestEmitImpossibleFloats(t *testing.T) {
+	values := []float64{
+		math.NaN(),
+		math.Inf(+1),
+		math.Inf(-1),
+	}
+
+	for _, v := range values {
+		t.Run(fmt.Sprintf("emitting %v must return an error", v), func(t *testing.T) {
+			e := Emitter{}
+
+			if err := e.EmitFloat(v, 64); err == nil {
+				t.Error("no error was returned")
+			}
+		})
 	}
 }


### PR DESCRIPTION
Mirroring the behavior of `encoding/json` here.