### PR TITLE
add resp.Error.Type()

### DIFF
--- a/resp/error.go
+++ b/resp/error.go
@@ -1,5 +1,10 @@
 package resp
 
+import (
+	"strings"
+	"unicode"
+)
+
 // The Error type represents redis errors.
 type Error string
 
@@ -12,4 +17,25 @@ func NewError(s string) *Error {
 // Error satsifies the error interface.
 func (e *Error) Error() string {
 	return string(*e)
+}
+
+// Type returns the RESP error type, which is represented by the leading
+// uppercase word in the error string.
+func (e *Error) Type() string {
+	s := e.Error()
+
+	if i := strings.IndexByte(s, ' '); i < 0 {
+		s = ""
+	} else {
+		s = s[:i]
+
+		for _, c := range s {
+			if !unicode.IsUpper(c) {
+				s = ""
+				break
+			}
+		}
+	}
+
+	return s
 }

--- a/resp/error_test.go
+++ b/resp/error_test.go
@@ -1,0 +1,31 @@
+package resp
+
+import "testing"
+
+func TestErrorType(t *testing.T) {
+	tests := []struct {
+		err Error
+		typ string
+	}{
+		{
+			err: Error("ERR wrong number of arguments for 'set' command"),
+			typ: "ERR",
+		},
+		{
+			err: Error(""),
+			typ: "",
+		},
+		{
+			err: Error("hello world!"),
+			typ: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.err.Error(), func(t *testing.T) {
+			if typ := test.err.Type(); typ != test.typ {
+				t.Error("bad error type:", typ)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Errors returned by a redis server are always made of a leading uppercase code which represents the type of error that was encountered.

This PR adds a method to extract those codes with a call to the `resp.Error.Type()` method.

Please take a look and let me know if something should be changed.
