### PR TITLE
decode numbers from string and []byte

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -167,6 +167,24 @@ func (d Decoder) decodeIntFromType(t Type, to reflect.Value) (err error) {
 
 		i = int64(u)
 
+	case String:
+		var b []byte
+
+		if b, err = d.Parser.ParseString(); err != nil {
+			return
+		}
+
+		i, err = strconv.ParseInt(string(b), 10, 64)
+
+	case Bytes:
+		var b []byte
+
+		if b, err = d.Parser.ParseBytes(); err != nil {
+			return
+		}
+
+		i, err = strconv.ParseInt(string(b), 10, 64)
+
 	default:
 		err = typeConversionError(t, Int)
 	}
@@ -237,6 +255,24 @@ func (d Decoder) decodeUintFromType(t Type, to reflect.Value) (err error) {
 			}
 		}
 
+	case String:
+		var b []byte
+
+		if b, err = d.Parser.ParseString(); err != nil {
+			return
+		}
+
+		u, err = strconv.ParseUint(string(b), 10, 64)
+
+	case Bytes:
+		var b []byte
+
+		if b, err = d.Parser.ParseBytes(); err != nil {
+			return
+		}
+
+		u, err = strconv.ParseUint(string(b), 10, 64)
+
 	default:
 		err = typeConversionError(t, Uint)
 	}
@@ -283,6 +319,24 @@ func (d Decoder) decodeFloatFromType(t Type, to reflect.Value) (err error) {
 
 	case Float:
 		f, err = d.Parser.ParseFloat()
+
+	case String:
+		var b []byte
+
+		if b, err = d.Parser.ParseString(); err != nil {
+			return
+		}
+
+		f, err = strconv.ParseFloat(string(b), 64)
+
+	case Bytes:
+		var b []byte
+
+		if b, err = d.Parser.ParseBytes(); err != nil {
+			return
+		}
+
+		f, err = strconv.ParseFloat(string(b), 64)
 
 	default:
 		err = typeConversionError(t, Float)

--- a/decode_test.go
+++ b/decode_test.go
@@ -142,6 +142,15 @@ func TestDecoderDecodeType(t *testing.T) {
 		// string -> bytes
 		{"Hello World!", []byte("Hello World!")},
 
+		// string -> int
+		{"-42", -42},
+
+		// string -> uint
+		{"42", uint(42)},
+
+		// string -> float
+		{"42.2", 42.2},
+
 		// string -> time
 		{"2016-12-12T01:01:01.000Z", date},
 
@@ -156,6 +165,15 @@ func TestDecoderDecodeType(t *testing.T) {
 
 		// bytes -> string
 		{[]byte("Hello World!"), "Hello World!"},
+
+		// bytes -> int
+		{[]byte("-42"), -42},
+
+		// bytes -> uint
+		{[]byte("42"), uint(42)},
+
+		// bytes -> float
+		{[]byte("42.42"), 42.42},
 
 		// bytes -> time
 		{[]byte("2016-12-12T01:01:01.000Z"), date},


### PR DESCRIPTION
This PR allows objconv to convert a ```string``` or ```[]byte``` to ```int```, ```uint``` and ```float64```