### PR TITLE
[prototype] Add type-specific decoder code generator

### DIFF
--- a/cmd/objconvgen/main.go
+++ b/cmd/objconvgen/main.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"flag"
+
+	"github.com/segmentio/objconv/generate"
+)
+
+func main() {
+	var pkg string
+	var typ string
+	var output string
+
+	flag.StringVar(&pkg, "p", "", "The package containing the type to generate for")
+	flag.StringVar(&typ, "t", "", "The name of the type to generate for")
+	flag.StringVar(&output, "o", "", "The name of the file to generate into")
+
+	flag.Parse()
+
+	generate.GenerateDecode(pkg, typ)
+}

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -416,13 +416,7 @@ func generateStructFunc(basePkg string, g *generatorType) string {
 		if err != nil {
 			return res, err
 		}
-		var k string
-		if len(kb) > 0 {
-			k = *(*string)(unsafe.Pointer(&reflect.StringHeader{
-				Data: uintptr(unsafe.Pointer(&kb[0])),
-				Len: len(kb),
-			}))
-		}
+		k := *(*string)(unsafe.Pointer(&kb))
 		switch k {`, g.typeName(basePkg))
 	for f, ftyp := range g.structFields {
 		res += fmt.Sprintf(`
@@ -467,13 +461,7 @@ func generateTimeFunc() string {
 		if err != nil {
 			return time.Time{}, err
 		}
-		var tstr string
-		if len(b) > 0 {
-			tstr = *(*string)(unsafe.Pointer(&reflect.StringHeader{
-				Data: uintptr(unsafe.Pointer(&b[0])),
-				Len: len(b),
-			}))
-		}
+		tstr := *(*string)(unsafe.Pointer(&b))
 		return time.Parse(time.RFC3339Nano, tstr)
 	default:
 		return time.Time{}, fmt.Errorf("Cannot parse Time from type %s", typ.String())

--- a/generate/generate.go
+++ b/generate/generate.go
@@ -1,0 +1,481 @@
+package generate
+
+import (
+	"fmt"
+	"go/types"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/segmentio/objconv/objutil"
+	"golang.org/x/tools/go/loader"
+)
+
+type kind int
+
+const (
+	typBasic kind = iota
+	typArray
+	typStruct
+	typAlias
+	typTime
+)
+
+type generatorType struct {
+	kind kind
+
+	name string
+
+	pkgName string
+	pkgPath string
+
+	// the type aliased to, or the array element type
+	subType *generatorType
+
+	basicKind types.BasicKind
+
+	arrayLength int64
+
+	structFields map[structKey]*generatorType
+}
+
+func (g *generatorType) funcName() string {
+	switch g.kind {
+	case typArray:
+		return g.subType.funcName() + "_" + strconv.FormatInt(g.arrayLength, 10)
+	case typStruct:
+		return g.pkgName + "_" + g.name
+	case typAlias:
+		return g.pkgName + "_" + g.name
+	case typTime:
+		return "time_Time"
+	case typBasic:
+		return g.name
+	}
+	panic(g)
+}
+
+func (g *generatorType) typeName(basePkg string) string {
+	prefix := ""
+	if g.pkgPath != "" && g.pkgPath != basePkg {
+		prefix = g.pkgName + "."
+	}
+	switch g.kind {
+	case typArray:
+		return fmt.Sprintf("[%d]%s", g.arrayLength, g.subType.typeName(basePkg))
+	case typStruct:
+		return prefix + g.name
+	case typAlias:
+		return prefix + g.name
+	case typTime:
+		return "time.Time"
+	case typBasic:
+		return g.name
+	}
+	panic(g)
+}
+
+type structKey struct {
+	encodedName string
+	fieldName   string
+}
+
+func createGeneratorType(path string, typ string) (*generatorType, error) {
+	config := loader.Config{}
+
+	config.Import(path)
+	program, err := config.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	mainPkg := program.Package(path)
+
+	var typeObj types.Object
+	for k, def := range mainPkg.Defs {
+		if k.Name == typ {
+			typeObj = def
+			break
+		}
+	}
+	if typeObj == nil {
+		return nil, fmt.Errorf("Could not find type %s in %s", typ, path)
+	}
+
+	var walkType func(types.Type) *generatorType
+
+	walkType = func(t types.Type) *generatorType {
+		switch typ := t.(type) {
+		case *types.Basic:
+			return &generatorType{
+				kind:      typBasic,
+				basicKind: typ.Kind(),
+				name:      typ.Name(),
+			}
+		case *types.Named:
+			pkg := typ.Obj().Pkg()
+			if st, ok := typ.Underlying().(*types.Struct); ok {
+				if pkg.Name()+"."+typ.Obj().Name() == "time.Time" {
+					return &generatorType{
+						kind: typTime,
+					}
+				}
+
+				fields := make(map[structKey]*generatorType, st.NumFields())
+				for i := 0; i < st.NumFields(); i++ {
+					f := st.Field(i)
+					fields[structKey{
+						fieldName:   f.Name(),
+						encodedName: f.Name(), // TODO: support json,objconv tags
+					}] = walkType(f.Type())
+				}
+
+				return &generatorType{
+					kind:         typStruct,
+					name:         typ.Obj().Name(),
+					pkgName:      pkg.Name(),
+					pkgPath:      pkg.Path(),
+					structFields: fields,
+				}
+			}
+			// otherwise its an alias
+			return &generatorType{
+				kind:    typAlias,
+				name:    typ.Obj().Name(),
+				pkgName: pkg.Name(),
+				pkgPath: pkg.Path(),
+				subType: walkType(typ.Underlying()),
+			}
+		case *types.Array:
+			return &generatorType{
+				kind:        typArray,
+				subType:     walkType(typ.Elem()),
+				arrayLength: typ.Len(),
+			}
+		}
+
+		panic("UNKNOWN " + reflect.TypeOf(t).String())
+	}
+
+	return walkType(typeObj.Type()), nil
+}
+
+func GenerateDecode(path string, typ string) {
+	gtyp, err := createGeneratorType(path, typ)
+	if err != nil {
+		panic(err)
+	}
+
+	pkgs := map[string]struct{}{}
+	typs := map[string]*generatorType{}
+
+	var walk func(*generatorType)
+
+	walk = func(g *generatorType) {
+		typs[g.funcName()] = g
+		switch g.kind {
+		case typArray:
+			walk(g.subType)
+		case typStruct:
+			pkgs[g.pkgPath] = struct{}{}
+			for _, f := range g.structFields {
+				walk(f)
+			}
+		case typAlias:
+			pkgs[g.pkgPath] = struct{}{}
+			walk(g.subType)
+		case typTime:
+			pkgs["time"] = struct{}{}
+		}
+	}
+
+	walk(gtyp)
+
+	decoderName := gtyp.name + "Decoder"
+
+	pkgNames := make([]string, 0, len(pkgs))
+
+	for p := range pkgs {
+		if p == gtyp.pkgPath {
+			continue
+		}
+		pkgNames = append(pkgNames, `"`+p+`"`)
+	}
+
+	res := fmt.Sprintf(`package %[1]s
+
+import (
+	"reflect"
+	"unsafe"
+
+	%[2]s
+
+	"github.com/segmentio/objconv"
+	"github.com/segmentio/objconv/generate/util"
+)
+
+type %[3]s struct {
+	Parser objconv.Parser
+}
+
+func (d *%[3]s) Decode() (%[4]s, error) {
+	return d.decode_%[5]s()
+}`, gtyp.pkgName, strings.Join(pkgNames, "\n"), decoderName, gtyp.name, gtyp.funcName())
+
+	for _, t := range typs {
+		res += "\n\n" + generateDecodeFunc(decoderName, path, t)
+	}
+
+	fmt.Println(res)
+}
+
+func generateDecodeFunc(decoderName string, basePkg string, g *generatorType) string {
+	res := fmt.Sprintf("func (d *%[1]s) decode_%[2]s() (%[3]s, error) {", decoderName, g.funcName(), g.typeName(basePkg))
+
+	switch g.kind {
+	case typBasic:
+		res += generateBasicFunc(g)
+	case typArray:
+		res += generateArrayFunc(basePkg, g)
+	case typStruct:
+		res += generateStructFunc(basePkg, g)
+	case typAlias:
+		res += generateAliasFunc(basePkg, g)
+	case typTime:
+		res += generateTimeFunc()
+	}
+
+	res += "\n}"
+
+	return res
+}
+
+func generateBasicFunc(g *generatorType) string {
+	switch g.basicKind {
+	case types.Bool:
+		return `
+	return util.ParseBool(d.Parser)`
+
+	case types.Int:
+		return `
+	v, err := util.ParseInt(d.Parser)
+	return int(v), err`
+
+	case types.Int8:
+		return fmt.Sprintf(`
+	v, err := util.ParseInt(d.Parser)
+	if v > %d || v < %d {
+		err = fmt.Errorf("%%d does not fit in int8", v)
+	}
+	return int8(v), err`, objutil.Int8Max, objutil.Int8Min)
+
+	case types.Int16:
+		return fmt.Sprintf(`
+	v, err := util.ParseInt(d.Parser)
+	if v > %d || v < %d {
+		err = fmt.Errorf("%%d does not fit in int16", v)
+	}
+	return int16(v), err`, objutil.Int16Max, objutil.Int16Min)
+
+	case types.Int32:
+		return fmt.Sprintf(`
+	v, err := util.ParseInt(d.Parser)
+	if v > %d || v < %d {
+		err = fmt.Errorf("%%d does not fit in int32", v)
+	}
+	return int32(v), err`, objutil.Int32Max, objutil.Int32Min)
+
+	case types.Int64:
+		return `
+	return util.ParseInt(d.Parser)`
+
+	case types.Uint:
+		return `
+	v, err := util.ParseUint(d.Parser)
+	return uint(v), err`
+
+	case types.Uint8:
+		return fmt.Sprintf(`
+	v, err := util.ParseUint(d.Parser)
+	if v > %d {
+		err = fmt.Errorf("%%d does not fit in uint8", v)
+	}
+	return uint8(v), err`, objutil.Uint8Max)
+
+	case types.Uint16:
+		return fmt.Sprintf(`
+	v, err := util.ParseUint(d.Parser)
+	if v > %d {
+		err = fmt.Errorf("%%d does not fit in uint16", v)
+	}
+	return uint16(v), err`, objutil.Uint16Max)
+
+	case types.Uint32:
+		return fmt.Sprintf(`
+	v, err := util.ParseUint(d.Parser)
+	if v > %d {
+		err = fmt.Errorf("%%d does not fit in uint32", v)
+	}
+	return uint32(v), err`, objutil.Uint32Max)
+
+	case types.Uint64:
+		return `
+	return util.ParseUint(d.Parser)`
+
+	case types.Float32:
+		return `
+	v, err := util.ParseFloat(d.Parser)
+	return float32(v), err`
+
+	case types.Float64:
+		return `
+	return util.ParseFloat(d.Parser)`
+
+	case types.String:
+		return `
+	v, err := util.ParseString(d.Parser)
+	return string(v), err`
+
+	default:
+		panic(fmt.Errorf("Unknown basic kind %v (%s)", g.basicKind, g.name))
+	}
+}
+
+func generateArrayFunc(basePkg string, g *generatorType) string {
+	res := fmt.Sprintf(`
+	var res %[1]s
+	typ, err := d.Parser.ParseType()
+	if err != nil {
+		return res, err
+	}
+	if typ != objconv.Array {
+		return res, fmt.Errorf("Cannot decode value of type %%s into %[1]s", typ.String())
+	}
+	count, err := d.Parser.ParseArrayBegin()
+	if err != nil {
+		return res, err
+	}
+	if count >= 0 && count != %[2]d {
+		return res, fmt.Errorf("Cannot decode array of length %%d into %[1]s", count)
+	}
+	if count < 0 {
+		if err = d.Parser.ParseArrayNext(0); err != nil {
+			return res, err
+		}
+	}`, g.typeName(basePkg), g.arrayLength)
+	for i := 0; i < int(g.arrayLength); i++ {
+		res += fmt.Sprintf(`
+	res[%[1]d], err = d.decode_%[2]s()
+	if err != nil {
+		return res, err
+	}`, i, g.subType.funcName())
+	}
+	res += fmt.Sprintf(`
+	if count < 0 {
+		if err = d.Parser.ParseArrayNext(%[1]d); err == nil {
+			return res, errors.New("Cannot decode array greater than length %[1]d into %[2]s")
+		} else if err != objconv.End {
+			return res, err
+		}
+	}
+	return res, d.Parser.ParseArrayEnd(%[1]d)`, g.arrayLength, g.typeName(basePkg))
+	return res
+}
+
+func generateStructFunc(basePkg string, g *generatorType) string {
+	res := fmt.Sprintf(`
+	var res %[1]s
+	typ, err := d.Parser.ParseType()
+	if err != nil {
+		return res, err
+	}
+	if typ != objconv.Map {
+		return res, fmt.Errorf("Cannot decode value of type %%s into %[1]s", typ.String())
+	}
+	count, err := d.Parser.ParseMapBegin()
+	if err != nil {
+		return res, err
+	}
+	var i int
+	for i = 0; count < 0 || i < count; i++ {
+		if count < 0 || i != 0 {
+			if err = d.Parser.ParseMapNext(i); err == objconv.End {
+				break
+			} else if err != nil {
+				return res, err
+			}
+		}
+		ktyp, err := d.Parser.ParseType()
+		if err != nil {
+			return res, err
+		}
+		if ktyp != objconv.String {
+			return res, fmt.Errorf("Cannot decode %[1]s key from type %%s", ktyp.String())
+		}
+		kb, err := d.Parser.ParseString()
+		if err != nil {
+			return res, err
+		}
+		var k string
+		if len(kb) > 0 {
+			k = *(*string)(unsafe.Pointer(&reflect.StringHeader{
+				Data: uintptr(unsafe.Pointer(&kb[0])),
+				Len: len(kb),
+			}))
+		}
+		switch k {`, g.typeName(basePkg))
+	for f, ftyp := range g.structFields {
+		res += fmt.Sprintf(`
+		case "%[1]s":
+			if err = d.Parser.ParseMapValue(i); err != nil {
+				return res, err
+			}
+			res.%[2]s, err = d.decode_%[3]s()
+			if err != nil {
+				return res, err
+			}`, f.encodedName, f.fieldName, ftyp.funcName())
+	}
+	res += `
+		default:
+			if err = util.SkipValue(d.Parser); err != nil {
+				return res, err
+			}
+		}
+	}
+	err = d.Parser.ParseMapEnd(i)
+	return res, err`
+	return res
+}
+
+func generateAliasFunc(basePkg string, g *generatorType) string {
+	return fmt.Sprintf(`
+	v, err := d.decode_%s()
+	return %s(v), err`, g.subType.funcName(), g.typeName(basePkg))
+}
+
+func generateTimeFunc() string {
+	return `
+	typ, err := d.Parser.ParseType()
+	if err != nil {
+		return time.Time{}, err
+	}
+	switch typ {
+	case objconv.Time:
+		return d.Parser.ParseTime()
+	case objconv.String:
+		b, err := d.Parser.ParseString()
+		if err != nil {
+			return time.Time{}, err
+		}
+		var tstr string
+		if len(b) > 0 {
+			tstr = *(*string)(unsafe.Pointer(&reflect.StringHeader{
+				Data: uintptr(unsafe.Pointer(&b[0])),
+				Len: len(b),
+			}))
+		}
+		return time.Parse(time.RFC3339Nano, tstr)
+	default:
+		return time.Time{}, fmt.Errorf("Cannot parse Time from type %s", typ.String())
+	}`
+}

--- a/generate/genutil/util.go
+++ b/generate/genutil/util.go
@@ -1,4 +1,4 @@
-package util
+package genutil
 
 import (
 	"fmt"
@@ -116,7 +116,8 @@ func ParseInt(p objconv.Parser) (int64, error) {
 	case objconv.Float:
 		var fv float64
 		fv, err = p.ParseFloat()
-		if float64(int64(fv)) != fv {
+		v = int64(fv)
+		if float64(fv) != fv {
 			err = fmt.Errorf("objconv: %f does not fit in int64", fv)
 		}
 	default:

--- a/generate/util/util.go
+++ b/generate/util/util.go
@@ -1,0 +1,235 @@
+package util
+
+import (
+	"fmt"
+	"reflect"
+	"time"
+	"unsafe"
+
+	"github.com/segmentio/objconv"
+	"github.com/segmentio/objconv/objutil"
+)
+
+// SkipValue properly skips a value in a parser based on the type
+func SkipValue(p objconv.Parser) (err error) {
+	var typ objconv.Type
+
+	typ, err = p.ParseType()
+	if err != nil {
+		return err
+	}
+
+	switch typ {
+	case objconv.Nil:
+		return p.ParseNil()
+	case objconv.Bool:
+		_, err = p.ParseBool()
+	case objconv.Int:
+		_, err = p.ParseInt()
+	case objconv.Uint:
+		_, err = p.ParseUint()
+	case objconv.Float:
+		_, err = p.ParseFloat()
+	case objconv.String:
+		_, err = p.ParseString()
+	case objconv.Bytes:
+		_, err = p.ParseBytes()
+	case objconv.Time:
+		_, err = p.ParseTime()
+	case objconv.Duration:
+		_, err = p.ParseDuration()
+	case objconv.Error:
+		_, err = p.ParseError()
+	case objconv.Array:
+		var count int
+		count, err = p.ParseArrayBegin()
+		if err != nil {
+			return
+		}
+		var i int
+		for i = 0; count < 0 || i < count; i++ {
+			if count < 0 || i != 0 {
+				err = p.ParseArrayNext(i)
+				if err == objconv.End {
+					break
+				}
+				if err != nil {
+					return
+				}
+			}
+			if err = SkipValue(p); err != nil {
+				return
+			}
+		}
+		err = p.ParseArrayEnd(i)
+	case objconv.Map:
+		var count int
+		count, err = p.ParseMapBegin()
+		if err != nil {
+			return err
+		}
+		var i int
+		for i = 0; count < 0 || i < count; i++ {
+			if count < 0 || i != 0 {
+				err = p.ParseMapNext(i)
+				if err == objconv.End {
+					break
+				}
+				if err != nil {
+					return
+				}
+			}
+			if err = SkipValue(p); err != nil {
+				return
+			}
+			if err = p.ParseMapValue(i); err != nil {
+				return
+			}
+			if err = SkipValue(p); err != nil {
+				return
+			}
+		}
+		err = p.ParseMapEnd(i)
+	default:
+		err = fmt.Errorf("Unknown type: %v", typ)
+	}
+	return
+}
+
+// ParseInt parses a value into an int64
+func ParseInt(p objconv.Parser) (int64, error) {
+	typ, err := p.ParseType()
+	if err != nil {
+		return 0, err
+	}
+	var v int64
+	switch typ {
+	case objconv.Int:
+		v, err = p.ParseInt()
+	case objconv.Uint:
+		var uv uint64
+		uv, err = p.ParseUint()
+		if uv > objutil.Int64Max {
+			err = fmt.Errorf("objconv: %d does not fit in int64", uv)
+		}
+		v = int64(uv)
+	case objconv.Float:
+		var fv float64
+		fv, err = p.ParseFloat()
+		if float64(int64(fv)) != fv {
+			err = fmt.Errorf("objconv: %f does not fit in int64", fv)
+		}
+	default:
+		err = fmt.Errorf("objconv: cannot decode %s into int64", typ.String())
+	}
+	return v, err
+}
+
+// ParseUint parses a value into a uint64
+func ParseUint(p objconv.Parser) (uint64, error) {
+	typ, err := p.ParseType()
+	if err != nil {
+		return 0, err
+	}
+	var v uint64
+	switch typ {
+	case objconv.Int:
+		var iv int64
+		iv, err = p.ParseInt()
+		if iv < 0 {
+			err = fmt.Errorf("objconv: %d does not fit in uint64", iv)
+		}
+	case objconv.Uint:
+		v, err = p.ParseUint()
+	case objconv.Float:
+		var fv float64
+		fv, err = p.ParseFloat()
+		v = uint64(fv)
+		if float64(v) != fv {
+			err = fmt.Errorf("objconv: %f does not fit in uint64", fv)
+		}
+	default:
+		err = fmt.Errorf("objconv: cannot decode %s into uint64", typ.String())
+	}
+	return v, err
+}
+
+// ParseString parses a value into a string
+func ParseString(p objconv.Parser) ([]byte, error) {
+	typ, err := p.ParseType()
+	if err != nil {
+		return nil, err
+	}
+	var b []byte
+	switch typ {
+	case objconv.String:
+		b, err = p.ParseString()
+	case objconv.Bytes:
+		b, err = p.ParseBytes()
+	default:
+		err = fmt.Errorf("objconv: cannot decode %s into string", typ.String())
+	}
+	return b, err
+}
+
+// ParseFloat parses a value into a float64
+func ParseFloat(p objconv.Parser) (float64, error) {
+	typ, err := p.ParseType()
+	if err != nil {
+		return 0, err
+	}
+	var v float64
+	switch typ {
+	case objconv.Int:
+		var iv int64
+		iv, err = p.ParseInt()
+		v = float64(iv)
+	case objconv.Uint:
+		var uv uint64
+		uv, err = p.ParseUint()
+		v = float64(uv)
+	case objconv.Float:
+		v, err = p.ParseFloat()
+	default:
+		err = fmt.Errorf("objconv: cannot decode %s into float64", typ.String())
+	}
+
+	return v, err
+}
+
+// ParseBool parses a value into a bool
+func ParseBool(p objconv.Parser) (bool, error) {
+	typ, err := p.ParseType()
+	if err != nil {
+		return false, err
+	}
+	if typ != objconv.Bool {
+		return false, fmt.Errorf("objconv: cannot decode %s into bool", typ.String())
+	}
+	return p.ParseBool()
+}
+
+// ParseTime parses a value into a time.Time
+func ParseTime(p objconv.Parser) (time.Time, error) {
+	typ, err := p.ParseType()
+	if err != nil {
+		return time.Time{}, err
+	}
+	if typ == objconv.Time {
+		return p.ParseTime()
+	}
+	if typ != objconv.String {
+		return time.Time{}, fmt.Errorf("objconv: cannot decode %s into time.Time", typ.String())
+	}
+	b, err := p.ParseString()
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	tstr := *(*string)(unsafe.Pointer(&reflect.StringHeader{
+		Data: uintptr(unsafe.Pointer(&b[0])),
+		Len:  len(b),
+	}))
+
+	return time.ParseInLocation(time.RFC3339Nano, tstr, time.UTC)
+}


### PR DESCRIPTION
This adds a new `objconvgen` entrypoint that generates a optimized decoder for a specific type. Since the decoder doesn't need to use reflection and can return all results by-value, it attains a significant speedup from the generic parsing.

Since this is a prototype, I'd like to get some feedback on the approach I took. Any and all suggestions and feedback are welcome. This is a pretty big feature, so I'd like everyone to be on board with it.

Sample benchmark on a structure with strings, times, and nested arrays
```
BenchmarkDecodeCBOR-8                  200000          6431 ns/op          80 B/op           6 allocs/op
BenchmarkDecodeJSON-8                  200000          8607 ns/op          80 B/op           6 allocs/op
BenchmarkDecodeCBORGenerated-8         500000          3319 ns/op          48 B/op           5 allocs/op
BenchmarkDecodeJSONGenerated-8         300000          5425 ns/op          48 B/op           5 allocs/op
```

What's supported right now:
- structures
- arrays (not slices)
- primitives
- `time.Time`
- aliased types
- types in different packages

What's not supported right now:
- slices
- maps
- `time.Duration`
- `[]byte/[N]byte` special case

What definitely needs to be done before this could be merged:
- support `json` and `objconv` struct tags
- write the output to a file and `goimports/gofmt` it
- add tests on some generated code
- add benchmarks on some generated code

What would be nice to clean up before this is merged:
- remove dependence of generated code on `github.com/segmentio/objconv/generate/util` package